### PR TITLE
Fix improper escapes in third tokenizer domjs test

### DIFF
--- a/tokenizer/domjs.test
+++ b/tokenizer/domjs.test
@@ -77,8 +77,8 @@
         {
             "description":"--!NUL in comment ",
             "doubleEscaped":true,
-            "input":"<!----!\\u0000-->",
-            "output":["ParseError", ["Comment", "--!\\uFFFD"]]
+            "input":"<!----!\u0000-->",
+            "output":["ParseError", ["Comment", "--!\uFFFD"]]
         },
         {
             "description":"space EOF after doctype ",


### PR DESCRIPTION
The test descriptions mention NUL, but U+0000 doesn't actually appear in the tests. I'm guessing these were improperly escaped?
