### PR TITLE
<command> element no longer exists.

### DIFF
--- a/tree-construction/tests25.dat
+++ b/tree-construction/tests25.dat
@@ -84,7 +84,7 @@
 |   <head>
 |   <body>
 |     <command>
-|     "A"
+|       "A"
 
 #data
 <!DOCTYPE html><body><embed>A


### PR DESCRIPTION
It once parsed as if its self-closing flag was always set. As it is no longer in the spec, it now parses as an ordinary element, and the text node becomes its child.
