### PR TITLE
Double-escape a troublesome tokenizer test

### DIFF
--- a/tokenizer/domjs.test
+++ b/tokenizer/domjs.test
@@ -19,8 +19,9 @@
         },
         {
             "description":"leading U+FEFF must pass through",
-            "input":"\uFEFFfoo\uFEFFbar",
-            "output":[["Character", "\uFEFFfoo\uFEFFbar"]]
+            "doubleEscaped":true,
+            "input":"\\uFEFFfoo\\uFEFFbar",
+            "output":[["Character", "\\uFEFFfoo\\uFEFFbar"]]
         },
         {
             "description":"Non BMP-charref in in RCDATA",


### PR DESCRIPTION
I had issues with this test using the stock Ruby (2.0) and Objective-C (NSJSONSerialization) JSON decoders. And I don't think this change will affect anyone who properly implements the `doubleEscaped` value.
