### PR TITLE
Add tree-construction tests...

### DIFF
--- a/tree-construction/template.dat
+++ b/tree-construction/template.dat
@@ -1269,3 +1269,52 @@
 |       <template>
 |         content
 |           <span>
+
+#data
+<body><table><tr><td><select><template>Foo</template><caption>A</table>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <table>
+|       <tbody>
+|         <tr>
+|           <td>
+|             <select>
+|               <template>
+|                 content
+|                   "Foo"
+|       <caption>
+|         "A"
+
+#data
+<body></body><template>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <template>
+|       content
+
+#data
+<head></head><template>
+#errors
+#document
+| <html>
+|   <head>
+|     <template>
+|       content
+|   <body>
+
+#data
+<head></head><template>Foo</template>
+#errors
+#document
+| <html>
+|   <head>
+|     <template>
+|       content
+|         "Foo"
+|   <body>


### PR DESCRIPTION
These tests cover encountering <template> in "in select in table", "after body" and "after head".

These tests have already been landed in blinks down-stream repo and are reflected in the whatwg spec.

-in select in table: http://www.whatwg.org/specs/web-apps/current-work/#reset-the-insertion-mode-appropriately (step 4)

-after body: http://www.whatwg.org/specs/web-apps/current-work/#parsing-main-afterbody ("anything else" defers to "in body"

-after head: http://www.whatwg.org/specs/web-apps/current-work/#reset-the-insertion-mode-appropriately (step 15.2)
