### PR TITLE
Fix #3: test ">" in script data double escaped dash state

### DIFF
--- a/tree-construction/scriptdata01.dat
+++ b/tree-construction/scriptdata01.dat
@@ -350,3 +350,16 @@ FOO<script type="text/plain">'<!-- <sCrIpt/'</script>BAR</script>QUX
 |       type="text/plain"
 |       "'<!-- <sCrIpt/'</script>BAR"
 |     "QUX"
+
+#data
+FOO<script><!--<script>-></script>--></script>QUX
+#errors
+(1,3): expected-doctype-but-got-chars
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO"
+|     <script>
+|       "<!--<script>-></script>-->"
+|     "QUX"


### PR DESCRIPTION
This test is written to ensure that it is treated differently to how it is in the script data double escaped dash dash state, as this was the bug html5lib-python used to have. Fixes #3.
