### PR TITLE
Fix bug #54, the implicit closing of a <rtc> tag by <rp>.

### DIFF
--- a/tree-construction/ruby.dat
+++ b/tree-construction/ruby.dat
@@ -195,7 +195,7 @@
 |       "a"
 |       <rtc>
 |         "b"
-|       <rp>
+|         <rp>
 
 #data
 <html><ruby>a<rtc>b<span></ruby></html>


### PR DESCRIPTION
Per discussion in #54, it seems like the expectation in the test is wrong and this will bring it inline with both the current W3C spec (which explicitly handles this case) and the WhatWG spec (which has no special handling for \<rtc> at all).