### PR TITLE
Add tests for integer overflow when a signed 32-bit integer is used for holding the numeric character reference value.

### DIFF
--- a/tokenizer/numericEntities.test
+++ b/tokenizer/numericEntities.test
@@ -1,5 +1,41 @@
 {"tests": [
 
+{"description": "Invalid unterminated numeric entity character overflow before EOF",
+"input": "&#11111111111",
+"output": ["ParseError", "ParseError", ["Character", "\uFFFD"]]},
+
+{"description": "Invalid unterminated numeric entity character overflow before EOF",
+"input": "&#1111111111",
+"output": ["ParseError", "ParseError", ["Character", "\uFFFD"]]},
+
+{"description": "Invalid unterminated numeric entity character overflow before EOF",
+"input": "&#111111111111",
+"output": ["ParseError", "ParseError", ["Character", "\uFFFD"]]},
+
+{"description": "Invalid unterminated numeric entity character overflow",
+"input": "&#11111111111x",
+"output": ["ParseError", "ParseError", ["Character", "\uFFFDx"]]},
+
+{"description": "Invalid unterminated numeric entity character overflow",
+"input": "&#1111111111x",
+"output": ["ParseError", "ParseError", ["Character", "\uFFFDx"]]},
+
+{"description": "Invalid unterminated numeric entity character overflow",
+"input": "&#111111111111x",
+"output": ["ParseError", "ParseError", ["Character", "\uFFFDx"]]},
+
+{"description": "Invalid numeric entity character overflow",
+"input": "&#11111111111;",
+"output": ["ParseError", ["Character", "\uFFFD"]]},
+
+{"description": "Invalid numeric entity character overflow",
+"input": "&#1111111111;",
+"output": ["ParseError", ["Character", "\uFFFD"]]},
+
+{"description": "Invalid numeric entity character overflow",
+"input": "&#111111111111;",
+"output": ["ParseError", ["Character", "\uFFFD"]]},
+
 {"description": "Invalid numeric entity character U+0000",
 "input": "&#x0000;",
 "output": ["ParseError", ["Character", "\uFFFD"]]},

--- a/tree-construction/entities01.dat
+++ b/tree-construction/entities01.dat
@@ -721,3 +721,72 @@ FOO&#xFFFFFF;ZOO
 |   <head>
 |   <body>
 |     "FOO�ZOO"
+
+#data
+FOO&#11111111111
+#errors
+(1,3): expected-doctype-but-got-chars
+(1,13): illegal-codepoint-for-numeric-entity
+(1,13): eof-in-numeric-entity
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO�"
+
+#data
+FOO&#1111111111
+#errors
+(1,3): expected-doctype-but-got-chars
+(1,13): illegal-codepoint-for-numeric-entity
+(1,13): eof-in-numeric-entity
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO�"
+
+#data
+FOO&#111111111111
+#errors
+(1,3): expected-doctype-but-got-chars
+(1,13): illegal-codepoint-for-numeric-entity
+(1,13): eof-in-numeric-entity
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO�"
+
+#data
+FOO&#11111111111ZOO
+#errors
+(1,3): expected-doctype-but-got-chars
+(1,13): illegal-codepoint-for-numeric-entity
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO�ZOO"
+
+#data
+FOO&#1111111111ZOO
+#errors
+(1,3): expected-doctype-but-got-chars
+(1,13): illegal-codepoint-for-numeric-entity
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO�ZOO"
+
+#data
+FOO&#111111111111ZOO
+#errors
+(1,3): expected-doctype-but-got-chars
+(1,13): illegal-codepoint-for-numeric-entity
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO�ZOO"


### PR DESCRIPTION
Sharing test cases for an integer overflow bug in the Validator.nu/Firefox HTML parser.