### PR TITLE
Don't pop the form for isindex in table (fragment)

### DIFF
--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -264,12 +264,12 @@ table
 #document
 | <form>
 |   action="x"
-| <hr>
-| <label>
-|   "This is a searchable index. Enter search keywords: "
-|   <input>
-|     name="isindex"
-| <hr>
+|   <hr>
+|   <label>
+|     "This is a searchable index. Enter search keywords: "
+|     <input>
+|       name="isindex"
+|   <hr>
 
 #data
 <option><XH<optgroup></optgroup>


### PR DESCRIPTION
As far as I can tell, https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inbody doesn't say to pop the form element here.

Also see discussion in http://krijnhoetmer.nl/irc-logs/whatwg/20150916#l-497