### PR TITLE
Move `#script-off` to the usual place relative to the other sections of a test

### DIFF
--- a/tree-construction/tests18.dat
+++ b/tree-construction/tests18.dat
@@ -51,11 +51,11 @@
 
 #data
 <!doctype html><html><noscript><plaintext></plaintext>
-#script-off
 #errors
 42: Bad start tag in “plaintext” in “head”.
 54: End of file seen and there were open elements.
 42: Unclosed element “plaintext”.
+#script-off
 #document
 | <!DOCTYPE html>
 | <html>


### PR DESCRIPTION
Having it in an unusual place breaks the test harness for the Validator.nu HTML Parser.