### PR TITLE
Comment errors

### DIFF
--- a/tree-construction/comments01.dat
+++ b/tree-construction/comments01.dat
@@ -29,7 +29,6 @@ FOO<!-- BAR --!>BAZ
 FOO<!-- BAR --   >BAZ
 #errors
 (1,3): expected-doctype-but-got-chars
-(1,15): unexpected-char-in-comment
 (1,21): eof-in-comment
 #new-errors
 (1:22) eof-in-comment
@@ -44,8 +43,6 @@ FOO<!-- BAR --   >BAZ
 FOO<!-- BAR -- <QUX> -- MUX -->BAZ
 #errors
 (1,3): expected-doctype-but-got-chars
-(1,15): unexpected-char-in-comment
-(1,24): unexpected-char-in-comment
 #document
 | <html>
 |   <head>
@@ -58,8 +55,6 @@ FOO<!-- BAR -- <QUX> -- MUX -->BAZ
 FOO<!-- BAR -- <QUX> -- MUX --!>BAZ
 #errors
 (1,3): expected-doctype-but-got-chars
-(1,15): unexpected-char-in-comment
-(1,24): unexpected-char-in-comment
 (1,31): unexpected-bang-after-double-dash-in-comment
 #new-errors
 (1:32) incorrectly-closed-comment
@@ -75,9 +70,6 @@ FOO<!-- BAR -- <QUX> -- MUX --!>BAZ
 FOO<!-- BAR -- <QUX> -- MUX -- >BAZ
 #errors
 (1,3): expected-doctype-but-got-chars
-(1,15): unexpected-char-in-comment
-(1,24): unexpected-char-in-comment
-(1,31): unexpected-char-in-comment
 (1,35): eof-in-comment
 #new-errors
 (1:36) eof-in-comment

--- a/tree-construction/comments01.dat
+++ b/tree-construction/comments01.dat
@@ -174,7 +174,6 @@ FOO<!-->BAZ
 FOO<!----->BAZ
 #errors
 (1,3): expected-doctype-but-got-chars
-(1,10): unexpected-dash-after-double-dash-in-comment
 #document
 | <html>
 |   <head>

--- a/tree-construction/html5test-com.dat
+++ b/tree-construction/html5test-com.dat
@@ -142,7 +142,6 @@
 #data
 <!--foo--bar-->
 #errors
-(1,10): unexpected-char-in-comment
 (1,15): expected-doctype-but-got-eof
 #document
 | <!-- foo--bar -->

--- a/tree-construction/tests1.dat
+++ b/tree-construction/tests1.dat
@@ -425,7 +425,6 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <!-----><font><div>hello<table>excite!<b>me!<th><i>please!</tr><!--X-->
 #errors
-(1,7): unexpected-dash-after-double-dash-in-comment
 (1,14): expected-doctype-but-got-start-tag
 (1,41): unexpected-start-tag-implies-table-voodoo
 (1,48): foster-parenting-character-in-table


### PR DESCRIPTION
I think these were formerly tokenizer errors but they no longer are.

Per #107, I understand that `#errors` should reflect the actual number of errors and that `#new-errors` are a way to transition to the new errors but I'm not sure if there's a way to indicate that errors have been removed.