### PR TITLE
Add missing errors

### DIFF
--- a/tree-construction/math.dat
+++ b/tree-construction/math.dat
@@ -1,6 +1,8 @@
 #data
 <math><tr><td><mo><tr>
 #errors
+(1,22): unexpected-start-tag
+(1,23): expected-closing-tag-but-got-eof
 #document-fragment
 td
 #document
@@ -12,6 +14,9 @@ td
 #data
 <math><tr><td><mo><tr>
 #errors
+(1,6): foster-parenting-start-tag
+(1,22): expected-tr-in-table-scope
+(1,23): expected-closing-tag-but-got-eof
 #document-fragment
 tr
 #document
@@ -23,6 +28,9 @@ tr
 #data
 <math><thead><mo><tbody>
 #errors
+(1,6): foster-parenting-start-tag
+(1,24): expected-table-part-in-table-scope
+(1,25): expected-closing-tag-but-got-eof
 #document-fragment
 thead
 #document
@@ -33,6 +41,9 @@ thead
 #data
 <math><tfoot><mo><tbody>
 #errors
+(1,6): foster-parenting-start-tag
+(1,24): expected-table-part-in-table-scope
+(1,25): expected-closing-tag-but-got-eof
 #document-fragment
 tfoot
 #document
@@ -43,6 +54,9 @@ tfoot
 #data
 <math><tbody><mo><tfoot>
 #errors
+(1,6): foster-parenting-start-tag
+(1,24): expected-table-part-in-table-scope
+(1,25): expected-closing-tag-but-got-eof
 #document-fragment
 tbody
 #document
@@ -53,6 +67,9 @@ tbody
 #data
 <math><tbody><mo></table>
 #errors
+(1,6): foster-parenting-start-tag
+(1,25): unexpected-end-tag-in-math
+(1,26): expected-closing-tag-but-got-eof
 #document-fragment
 tbody
 #document
@@ -63,6 +80,9 @@ tbody
 #data
 <math><thead><mo></table>
 #errors
+(1,6): foster-parenting-start-tag
+(1,25): unexpected-end-tag-in-math
+(1,26): expected-closing-tag-but-got-eof
 #document-fragment
 tbody
 #document
@@ -73,6 +93,9 @@ tbody
 #data
 <math><tfoot><mo></table>
 #errors
+(1,6): foster-parenting-start-tag
+(1,25): unexpected-end-tag-in-math
+(1,26): expected-closing-tag-but-got-eof
 #document-fragment
 tbody
 #document


### PR DESCRIPTION
These are tricky. A `<math>` tag as the first token in a document
fragment whose context node is `td` (or `th`, but this isn't tested
here) is fine. One in a document fragment whose context node is `tr`,
`thead`, `tbody`, or `tfoot` is a parse error and the elements are
foster parented.

The table element start tags after the `<mo>` tag are parsed as html and
there are no `tr` (for `tr` elements) elements or `thead`, `tbody`, or
`tfoot` (for the others) elements in table scope which is a parse error.
I just invented some sames for those.

The `</table>` tag after the `<mo>` is parsed as foreign but it doesn't
match `<mo>` so it's a parse error.

Finally, the EOF occurs while a bunch of elements are open which is a
parse error.