### PR TITLE
`<!doctype html><script><!` has only one error

### DIFF
--- a/tree-construction/tests16.dat
+++ b/tree-construction/tests16.dat
@@ -221,7 +221,6 @@
 <!doctype html><script><!
 #errors
 (1,25): expected-script-data-but-got-eof
-(1,25): expected-named-closing-tag-but-got-eof
 #document
 | <!DOCTYPE html>
 | <html>
@@ -1525,7 +1524,6 @@
 #errors
 (1,8): expected-doctype-but-got-start-tag
 (1,10): expected-script-data-but-got-eof
-(1,10): expected-named-closing-tag-but-got-eof
 #document
 | <html>
 |   <head>


### PR DESCRIPTION
Here are the (abbreviated) steps (intermingling the tree-construction
and tokenizer).

1. `<script>` token causes `html` and `head` elements to be inserted and
   is processed in the "in head" insertion mode
2. `<script>` token switches the tokenizer to the script data state and
   switches to the "text" insertion mode
3. `<` switches to the script data less-than sign state
4. `!` switches to the script data escape start state and emits `<!`
5. EOF is reconsumed in the script data state
6. EOF emits an EOF token
7. EOF token (in the "text" insertion mode) is a parse error,
   `<script>` is popped off the stack of open elements, switches back to
   the "in head" insertion mode and reprocesses the token
8. EOF token (in "in head") triggers the "anything else clause" which
   pops the `head` element, switches to "after head", inserts a `body`
   token, switches to "in body", and reprocesses
9. EOF token (in "in body") stops parsing with no error because the
   stack of open elements contains `html` and `body`

Only step 7 adds a parse error.