### PR TITLE
Fix entity errors

### DIFF
--- a/tree-construction/entities02.dat
+++ b/tree-construction/entities02.dat
@@ -45,7 +45,6 @@
 #data
 <div bar="ZZ&gt=YY"></div>
 #errors
-(1,15): named-entity-without-semicolon
 (1,20): expected-doctype-but-got-start-tag
 #document
 | <html>
@@ -204,7 +203,6 @@
 #data
 <div bar="ZZ&pound=23"></div>
 #errors
-(1,18): named-entity-without-semicolon
 (1,23): expected-doctype-but-got-start-tag
 #document
 | <html>
@@ -299,6 +297,8 @@
 #data
 <div>ZZ&AElig=</div>
 #errors
+(1,5): expected-doctype-but-got-start-tag
+(1:14) missing-semicolon-after-character-reference
 #new-errors
 (1:14) missing-semicolon-after-character-reference
 #document


### PR DESCRIPTION
Named character references in attributes whose last character is not `;`
and for which the next input character is `=` (or ASCII alphanumeric,
but this isn't tested here), flushes the code points consumed as a
character reference _without_ adding a parse error.

Named character references not in attributes whose last character is not
`;` are errors, regardless of the following character as noted in the
`#new-errors` section but without an entry in `#errors`, the number of
errors are wrong. (See
https://github.com/html5lib/html5lib-tests/issues/107).

Separately, this adds the missing expected-doctype-but-got-start-tag
error.