### PR TITLE
Fix template errors

### DIFF
--- a/tree-construction/template.dat
+++ b/tree-construction/template.dat
@@ -1089,7 +1089,11 @@ eof in template
 <body><template><col>Hello
 #errors
 no doctype
-unexpected text
+(1,27): foster-parenting-character
+(1,27): foster-parenting-character
+(1,27): foster-parenting-character
+(1,27): foster-parenting-character
+(1,27): foster-parenting-character
 eof in template
 #document
 | <html>
@@ -1593,6 +1597,11 @@ eof table
 #data
 <template><a><table><a>
 #errors
+(1,10): expected-doctype-but-got-start-tag
+(1,23): foster-parenting-start-tag
+(1,23): unexpected-start-tag
+(1,23): formatting-element-not-in-scope
+(1,24): eof-in-template
 #document
 | <html>
 |   <head>


### PR DESCRIPTION
Each character in the table (caused by the `<col>`) gets reparented and
causes an error.

The second `<a>` gets reparented but there's already one open, so that's
a second error but the open one is not in scope so that's a third error.