### PR TITLE
End tag causes two parse errors

### DIFF
--- a/tree-construction/tests20.dat
+++ b/tree-construction/tests20.dat
@@ -557,6 +557,7 @@
 <math><annotation-xml></svg>x
 #errors
 (1,6): expected-doctype-but-got-start-tag
+(1,28): unexpected-end-tag-in-math
 (1,28): unexpected-end-tag
 (1,29): expected-closing-tag-but-got-eof
 #document


### PR DESCRIPTION
```
<math><annotation-xml></svg>x
```

The `</svg>` is parsed in foreign context because
1. The stack of open elements is not empty;
2. The adjusted current node (`annotation-xml` element) is not in the
   HTML namespace;
3. The adjusted current node is not a MathML text integration point;
4. The adjusted current node is not a MathML text integration point
   (separate condition from 3);
5. The adjusted current node is a MathML `annotation-xml` element but
   the token (`</svg>`) is not a start tag;
6. The token is not a start tag (also the `annotation-xml` isn't an HTML
   integration point because it lacks a particular attribute);
7. The token isn't a character token (also the `annotation-xml` isn't an
   HTML integration point).

Thus the "any other end tag" clause of 12.2.6.5 "The rules for parsing
tokens in foreign context" applies.

The current node's tag name (`annotation-xml`) is not the same as the
tag name of the token (`svg`) so this is a parse error.

Since there's no `svg` element in the stack of open elements, the loop
in step 3 through 6 of the "any other end tag" clause exits when the
`body` element is reached. and the token is processed according to the
current insertion mode, "in body."

The `</svg>` matches the "any other end tag" of "in body." Since the
MathML `annotation-xml` element is not an HTML element but is special
which is a second parse error.