### PR TITLE
Add tests for line breaks in the comment end bang state

### DIFF
--- a/tokenizer/test3.test
+++ b/tokenizer/test3.test
@@ -954,6 +954,34 @@
     { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
 ]},
 
+{"description":"<!----! >",
+"input":"<!----! >",
+"output":[["Comment", "--! >"]],
+"errors":[
+    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+]},
+
+{"description":"<!----!LF>",
+"input":"<!----!\n>",
+"output":[["Comment", "--!\n>"]],
+"errors":[
+    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+]},
+
+{"description":"<!----!CR>",
+"input":"<!----!\r>",
+"output":[["Comment", "--!\n>"]],
+"errors":[
+    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+]},
+
+{"description":"<!----!CRLF>",
+"input":"<!----!\r\n>",
+"output":[["Comment", "--!\n>"]],
+"errors":[
+    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+]},
+
 {"description":"<!----!a",
 "input":"<!----!a",
 "output":[["Comment", "--!a"]],

--- a/tokenizer/test3.test
+++ b/tokenizer/test3.test
@@ -958,28 +958,28 @@
 "input":"<!----! >",
 "output":[["Comment", "--! >"]],
 "errors":[
-    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+    { "code": "eof-in-comment", "line": 1, "col": 9 }
 ]},
 
 {"description":"<!----!LF>",
 "input":"<!----!\n>",
 "output":[["Comment", "--!\n>"]],
 "errors":[
-    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+    { "code": "eof-in-comment", "line": 1, "col": 9 }
 ]},
 
 {"description":"<!----!CR>",
 "input":"<!----!\r>",
 "output":[["Comment", "--!\n>"]],
 "errors":[
-    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+    { "code": "eof-in-comment", "line": 1, "col": 9 }
 ]},
 
 {"description":"<!----!CRLF>",
 "input":"<!----!\r\n>",
 "output":[["Comment", "--!\n>"]],
 "errors":[
-    { "code": "incorrectly-closed-comment", "line": 1, "col": 8 }
+    { "code": "eof-in-comment", "line": 1, "col": 9 }
 ]},
 
 {"description":"<!----!a",

--- a/tree-construction/README.md
+++ b/tree-construction/README.md
@@ -21,9 +21,13 @@ final newline (on the last line) removed.
 Then there must be a line that says "\#errors". It must be followed by
 one line per parse error that a conformant checker would return. It
 doesn't matter what those lines are, although they can't be
-"\#document-fragment", "\#document", "\#script-off", "\#script-on", or
-empty, the only thing that matters is that there be the right number
-of parse errors.
+"\#new-errors", "\#document-fragment", "\#document", "\#script-off",
+"\#script-on", or empty, the only thing that matters is that there be
+the right number of parse errors.
+
+Then there \*may\* be a line that says "\#new-errors", which works like
+the "\#errors" section adding more errors to the expected number of
+errors.
 
 Then there \*may\* be a line that says "\#document-fragment", which must
 be followed by a newline (LF), followed by a string of characters that

--- a/tree-construction/comments01.dat
+++ b/tree-construction/comments01.dat
@@ -30,7 +30,7 @@ FOO<!-- BAR --! >BAZ
 #errors
 (1,3): expected-doctype-but-got-chars
 #new-errors
-(1:20) incorrectly-closed-comment
+(1:20) eof-in-comment
 #document
 | <html>
 |   <head>
@@ -44,7 +44,7 @@ FOO<!-- BAR --!
 #errors
 (1,3): expected-doctype-but-got-chars
 #new-errors
-(1:20) incorrectly-closed-comment
+(1:20) eof-in-comment
 #document
 | <html>
 |   <head>

--- a/tree-construction/comments01.dat
+++ b/tree-construction/comments01.dat
@@ -26,6 +26,34 @@ FOO<!-- BAR --!>BAZ
 |     "BAZ"
 
 #data
+FOO<!-- BAR --! >BAZ
+#errors
+(1,3): expected-doctype-but-got-chars
+#new-errors
+(1:20) incorrectly-closed-comment
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO"
+|     <!--  BAR --! >BAZ -->
+
+#data
+FOO<!-- BAR --!
+>BAZ
+#errors
+(1,3): expected-doctype-but-got-chars
+#new-errors
+(1:20) incorrectly-closed-comment
+#document
+| <html>
+|   <head>
+|   <body>
+|     "FOO"
+|     <!--  BAR --!
+>BAZ -->
+
+#data
 FOO<!-- BAR --   >BAZ
 #errors
 (1,3): expected-doctype-but-got-chars


### PR DESCRIPTION
Test cases inspired by a [Gecko bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1540675).