### PR TITLE
Add testcase for open attribute value

### DIFF
--- a/tokenizer/fuzz.test
+++ b/tokenizer/fuzz.test
@@ -1,0 +1,9 @@
+{"tests": [
+{"description":"Lots of started attributes, EOF in tag",
+"input":"<D/0=&\r0='>",
+"output":[],
+"errors":[
+    { "code": "unexpected-solidus-in-tag", "line": 1, "col": 2 },
+    { "code": "eof-in-tag", "line": 1, "col": 12 }
+]}
+]}


### PR DESCRIPTION
This is a curious testcase because html5ever appears to be failing it.
At least piping it to html5ever like so appears to produce:

```
$ echo -n -e "<D/0=&\r0='>" | cargo run --example tokenize
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/examples/tokenize`
ERROR: Bad character
TAG  : <d 0='&0=''>
OTHER: EOFToken

Tokenizer profile, in nanoseconds

       23885         total in token sink

       44610         total in tokenizer
       27019  60.6%  AttributeValue(Unquoted)
        5158  11.6%  Data
        4669  10.5%  TagOpen
        2174   4.9%  TagName
        1753   3.9%  SelfClosingStartTag
        1413   3.2%  BeforeAttributeName
        1382   3.1%  BeforeAttributeValue
        1042   2.3%  AttributeName

```

I could not find an older revision of the spec (in w3 or whatwg) that
would explain this behavior.

It's late and I'm tired, but I believe my reading of the spec is correct
and this should not emit a tag.
