### PR TITLE
Fix tokenizer EOF error positions

### DIFF
--- a/tokenizer/entities.test
+++ b/tokenizer/entities.test
@@ -2,10 +2,7 @@
 
 {"description": "Undefined named entity in a double-quoted attribute value ending in semicolon and whose name starts with a known entity name.",
 "input":"<h a=\"&noti;\">",
-"output": [["StartTag", "h", {"a": "&noti;"}]],
-"errors":[
-    { "code": "unknown-named-character-reference", "line": 1, "col": 12 }
-]},
+"output": [["StartTag", "h", {"a": "&noti;"}]]},
 
 {"description": "Entity name requiring semicolon instead followed by the equals sign in a double-quoted attribute value.",
 "input":"<h a=\"&lang=\">",
@@ -17,10 +14,7 @@
 
 {"description": "Undefined named entity in a single-quoted attribute value ending in semicolon and whose name starts with a known entity name.",
 "input":"<h a='&noti;'>",
-"output": [["StartTag", "h", {"a": "&noti;"}]],
-"errors":[
-    { "code": "unknown-named-character-reference", "line": 1, "col": 12 }
-]},
+"output": [["StartTag", "h", {"a": "&noti;"}]]},
 
 {"description": "Entity name requiring semicolon instead followed by the equals sign in a single-quoted attribute value.",
 "input":"<h a='&lang='>",
@@ -32,10 +26,7 @@
 
 {"description": "Undefined named entity in an unquoted attribute value ending in semicolon and whose name starts with a known entity name.",
 "input":"<h a=&noti;>",
-"output": [["StartTag", "h", {"a": "&noti;"}]],
-"errors":[
-    { "code": "unknown-named-character-reference", "line": 1, "col": 11 }
-]},
+"output": [["StartTag", "h", {"a": "&noti;"}]]},
 
 {"description": "Entity name requiring semicolon instead followed by the equals sign in an unquoted attribute value.",
 "input":"<h a=&lang=>",

--- a/tokenizer/entities.test
+++ b/tokenizer/entities.test
@@ -2,7 +2,10 @@
 
 {"description": "Undefined named entity in a double-quoted attribute value ending in semicolon and whose name starts with a known entity name.",
 "input":"<h a=\"&noti;\">",
-"output": [["StartTag", "h", {"a": "&noti;"}]]},
+"output": [["StartTag", "h", {"a": "&noti;"}]],
+"errors":[
+    { "code": "unknown-named-character-reference", "line": 1, "col": 12 }
+]},
 
 {"description": "Entity name requiring semicolon instead followed by the equals sign in a double-quoted attribute value.",
 "input":"<h a=\"&lang=\">",
@@ -14,7 +17,10 @@
 
 {"description": "Undefined named entity in a single-quoted attribute value ending in semicolon and whose name starts with a known entity name.",
 "input":"<h a='&noti;'>",
-"output": [["StartTag", "h", {"a": "&noti;"}]]},
+"output": [["StartTag", "h", {"a": "&noti;"}]],
+"errors":[
+    { "code": "unknown-named-character-reference", "line": 1, "col": 12 }
+]},
 
 {"description": "Entity name requiring semicolon instead followed by the equals sign in a single-quoted attribute value.",
 "input":"<h a='&lang='>",
@@ -26,7 +32,10 @@
 
 {"description": "Undefined named entity in an unquoted attribute value ending in semicolon and whose name starts with a known entity name.",
 "input":"<h a=&noti;>",
-"output": [["StartTag", "h", {"a": "&noti;"}]]},
+"output": [["StartTag", "h", {"a": "&noti;"}]],
+"errors":[
+    { "code": "unknown-named-character-reference", "line": 1, "col": 11 }
+]},
 
 {"description": "Entity name requiring semicolon instead followed by the equals sign in an unquoted attribute value.",
 "input":"<h a=&lang=>",

--- a/tokenizer/test3.test
+++ b/tokenizer/test3.test
@@ -10,7 +10,7 @@
 "input":"",
 "output":[],
 "errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+    { "code": "eof-in-cdata", "line": 1, "col": 1 }
 ]},
 
 {"description":"\\u0009",
@@ -36,7 +36,7 @@
 "input":"\u000A",
 "output":[["Character", "\u000A"]],
 "errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+    { "code": "eof-in-cdata", "line": 2, "col": 1 }
 ]},
 
 {"description":"\\u000B",
@@ -443,7 +443,7 @@
 "input":";\uDBC0\uDC00",
 "output":[["Character", ";\uDBC0\uDC00"]],
 "errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+    { "code": "eof-in-cdata", "line": 1, "col": 4 }
 ]},
 
 {"description":"<",
@@ -1325,28 +1325,28 @@
 "input":"<!----! >",
 "output":[["Comment", "--! >"]],
 "errors":[
-    { "code": "eof-in-comment", "line": 1, "col": 9 }
+    { "code": "eof-in-comment", "line": 1, "col": 10 }
 ]},
 
 {"description":"<!----!LF>",
 "input":"<!----!\n>",
 "output":[["Comment", "--!\n>"]],
 "errors":[
-    { "code": "eof-in-comment", "line": 1, "col": 9 }
+    { "code": "eof-in-comment", "line": 2, "col": 2 }
 ]},
 
 {"description":"<!----!CR>",
 "input":"<!----!\r>",
 "output":[["Comment", "--!\n>"]],
 "errors":[
-    { "code": "eof-in-comment", "line": 1, "col": 9 }
+    { "code": "eof-in-comment", "line": 2, "col": 2 }
 ]},
 
 {"description":"<!----!CRLF>",
 "input":"<!----!\r\n>",
 "output":[["Comment", "--!\n>"]],
 "errors":[
-    { "code": "eof-in-comment", "line": 1, "col": 9 }
+    { "code": "eof-in-comment", "line": 2, "col": 2 }
 ]},
 
 {"description":"<!----!a",
@@ -11227,7 +11227,7 @@
 "input":"\uDBC0\uDC00",
 "output":[["Character", "\uDBC0\uDC00"]],
 "errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
 ]}
 
 ]}


### PR DESCRIPTION
I am trying to move [parse5](https://github.com/inikulin/parse5) to the upstream html5lib-tests repo (away from [this fork](https://github.com/HTMLParseErrorWG/html5lib-tests)). As a first PR to come from this effort, this PR corrects some tokenizer errors. The changes are in three categories:

1. Off-by-one errors for EOF errors. Most EOF errors already point at the column after the last character, with some exceptions. These exceptions were fixed.
2. Line breaks being ignored by some EOF errors. Similar to (1), these are the exception.
3. ~~`unknown-named-character-reference` errors were missing entirely and have been added.~~ Reverted.