### PR TITLE
Correct the test case from 56d589a to meet format expectations

### DIFF
--- a/tree-construction/template.dat
+++ b/tree-construction/template.dat
@@ -1614,9 +1614,9 @@ eof table
 
 #data
 <template><form><input name="q"></form><div>second</div></template>
+#errors
 #document-fragment
 template
-#errors
 #document
 | <template>
 |   content


### PR DESCRIPTION
The relevant formatting rule from the tree-construction README:

> Each test must begin with a string "\#data" followed by a newline (LF).
> All subsequent lines until a line that says "\#errors" are the test data
> and must be passed to the system being tested unchanged, except with the
> final newline (on the last line) removed.
>
> Then there must be a line that says "\#errors".

Commit 56d589a placed `#errors` after `#document-fragment`, so this pull request fixes that.

cc @stevecheckoway 