### PR TITLE
Fix test for `</button>` closing `<p>`

### DIFF
--- a/tree-construction/tests20.dat
+++ b/tree-construction/tests20.dat
@@ -511,9 +511,6 @@
 #data
 <!doctype html><button><p></button>x
 #errors
-(1,35): end-tag-too-early
-(1,36): expected-named-closing-tag-but-got-eof
-(1,36): expected-closing-tag-but-got-eof
 #document
 | <!DOCTYPE html>
 | <html>


### PR DESCRIPTION
The document `<!doctype html><button><p></button>x` has no errors.

See https://github.com/html5lib/html5lib-tests/pull/146#issuecomment-1151632526 for my analysis.