### PR TITLE
ci: add a skeleton github actions workflow for downstream projects

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,21 @@
+name: downstream
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - '*'
+
+jobs:
+  skeleton:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello world


### PR DESCRIPTION
This is one idea to start a CI suite for downstream tests, see the conversation at #141.

The goal here is to have a skeleton workflow that can be manually inspected by the maintainers and merged onto `master`. Once this file is on `master`, then subsequent PRs that modify the workflow file will (unless configured otherwise) run the workflow on the PR, which is the end goal of #141.

This workflow follows some practices that I've found useful:

- the `concurrency` section means that if a push to an existing PR or to `master` happens while the workflow is running, the run is canceled and new one is kicked off
- `on: workflow_dispatch` means that you can kick off a test run manually via Github's web UI
- the `on: push` section will run the workflow on any push to `master`
- the `on: pull_request` section will run the workflow just once for any change to a PR ("open" or "synchronize") -- by default GA will run the workflow twice when commits are pushed onto an existing PR

And the final `jobs` section is just a placeholder job that can be removed after this is merged.
