### PR TITLE
Fix template not having surrounding document

### DIFF
--- a/tree-construction/template.dat
+++ b/tree-construction/template.dat
@@ -1636,13 +1636,16 @@ eof table
 <template><form><input name="q"></form><div>second</div></template>
 #errors
 #document
-| <template>
-|   content
-|     <form>
-|       <input>
-|         name="q"
-|     <div>
-|       "second"
+| <html>
+|   <head>
+|     <template>
+|       content
+|         <form>
+|           <input>
+|             name="q"
+|         <div>
+|           "second"
+|   <body>
 
 #data
 <!DOCTYPE HTML><template><tr><td>cell</td></tr></template>


### PR DESCRIPTION
#158 removed the fragment mode, without updating the expected document.

Originated in https://github.com/inikulin/parse5/pull/877.