### PR TITLE
Provide errors for test introduced in #163

### DIFF
--- a/tree-construction/tables01.dat
+++ b/tree-construction/tables01.dat
@@ -288,6 +288,13 @@
 #data
 <div><table><svg><foreignObject><select><table><s>
 #errors
+1:1: Expected a doctype token
+1:13: 'svg' tag isn't allowed here. Currently open tags: html, body, div, table.
+1:33: 'select' tag isn't allowed here. Currently open tags: html, body, div, table, svg, foreignobject.
+1:41: 'table' tag isn't allowed here. Currently open tags: html, body, div, table, svg, foreignobject, select.
+1:41: 'table' tag isn't allowed here. Currently open tags: html, body, div, table, svg, foreignobject.
+1:48: 's' tag isn't allowed here. Currently open tags: html, body, div, table.
+1:51: Premature end of file. Currently open tags: html, body, div, table, s.
 #document
 | <html>
 |   <head>


### PR DESCRIPTION
The test introduced in #163 didn't specify the errors generated by the parser given that input. In this PR, I've specified the errors generated by Nokogiri's fork of the Gumbo parser.

If and when #154 et al are merged, these omissions should be more visible.
