### PR TITLE
Add testcase: Incorrectly opened comment in script data

### DIFF
--- a/tokenizer/test4.test
+++ b/tokenizer/test4.test
@@ -527,6 +527,16 @@
 "output":[],
 "errors":[
     { "code": "eof-in-tag", "line": 1, "col": 10 }
+]},
+
+{"description":"EOF in comment in script data",
+"input": "<script><!",
+"output": [
+    ["StartTag", "script", {}],
+    ["Comment", ""]
+],
+"errors": [
+    {"code": "incorrectly-opened-comment", "line": 1, "col": 10 }
 ]}
 
 ]}


### PR DESCRIPTION
lol-html fails this testcase because its "tokenizer" aims to be too
smart and infers state change based on script data. It's a problem with
their test harness because they run the wrong layer of abstraction IMO.

I just sort of winged the line/col information, it would be good to get
those CI PRs merged so there's some sanity checks.
