### PR TITLE
Move all CDATA section tests into one file

### DIFF
--- a/tokenizer/README.md
+++ b/tokenizer/README.md
@@ -52,7 +52,7 @@ tokenizer state which can be one of the following:
 -   `RCDATA state`
 -   `RAWTEXT state`
 -   `Script data state`
--   `CDATA section state`
+-   `CDATA section state` (only occurs in `cdataSection.test`)
 
  The test should be run once for each string, using it
 to set the tokenizer's initial state for that run. If

--- a/tokenizer/cdataSection.test
+++ b/tokenizer/cdataSection.test
@@ -1,0 +1,450 @@
+{
+    "tests": [
+        {
+            "description":"NUL in CDATA section",
+            "doubleEscaped":true,
+            "initialStates":["CDATA section state"],
+            "input":"\\u0000]]>",
+            "output":[["Character", "\\u0000"]]
+        },
+        {
+            "description":"CDATA content",
+            "input":"foo&#32;]]>",
+            "initialStates":["CDATA section state"],
+            "output":[["Character", "foo&#32;"]]
+        },
+        {
+            "description":"CDATA followed by HTML content",
+            "input":"foo&#32;]]>&#32;",
+            "initialStates":["CDATA section state"],
+            "output":[["Character", "foo&#32; "]]
+        },
+        {
+            "description":"CDATA with extra bracket",
+            "input":"foo]]]>",
+            "initialStates":["CDATA section state"],
+            "output":[["Character", "foo]"]]
+        },
+        {
+            "description":"CDATA without end marker",
+            "input":"foo",
+            "initialStates":["CDATA section state"],
+            "output":[["Character", "foo"]],
+            "errors":[
+                { "code": "eof-in-cdata", "line": 1, "col": 4 }
+            ]
+        },
+        {
+            "description":"CDATA with single bracket ending",
+            "input":"foo]",
+            "initialStates":["CDATA section state"],
+            "output":[["Character", "foo]"]],
+            "errors":[
+                { "code": "eof-in-cdata", "line": 1, "col": 5 }
+            ]
+        },
+        {
+            "description":"CDATA with two brackets ending",
+            "input":"foo]]",
+            "initialStates":["CDATA section state"],
+            "output":[["Character", "foo]]"]],
+            "errors":[
+                { "code": "eof-in-cdata", "line": 1, "col": 6 }
+            ]
+        },
+
+{"description":"[empty]",
+"initialStates":["CDATA section state"],
+"input":"",
+"output":[],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 1 }
+]},
+
+{"description":"\\u0009",
+"initialStates":["CDATA section state"],
+"input":"\u0009",
+"output":[["Character", "\u0009"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"\\u000A",
+"initialStates":["CDATA section state"],
+"input":"\u000A",
+"output":[["Character", "\u000A"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 2, "col": 1 }
+]},
+
+{"description":"\\u000B",
+"initialStates":["CDATA section state"],
+"input":"\u000B",
+"output":[["Character", "\u000B"]],
+"errors":[
+    { "code": "control-character-in-input-stream", "line": 1, "col": 1 },
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"\\u000C",
+"initialStates":["CDATA section state"],
+"input":"\u000C",
+"output":[["Character", "\u000C"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":" ",
+"initialStates":["CDATA section state"],
+"input":" ",
+"output":[["Character", " "]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"!",
+"initialStates":["CDATA section state"],
+"input":"!",
+"output":[["Character", "!"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"\"",
+"initialStates":["CDATA section state"],
+"input":"\"",
+"output":[["Character", "\""]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"%",
+"initialStates":["CDATA section state"],
+"input":"%",
+"output":[["Character", "%"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"&",
+"initialStates":["CDATA section state"],
+"input":"&",
+"output":[["Character", "&"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"'",
+"initialStates":["CDATA section state"],
+"input":"'",
+"output":[["Character", "'"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":",",
+"initialStates":["CDATA section state"],
+"input":",",
+"output":[["Character", ","]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"-",
+"initialStates":["CDATA section state"],
+"input":"-",
+"output":[["Character", "-"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":".",
+"initialStates":["CDATA section state"],
+"input":".",
+"output":[["Character", "."]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"/",
+"initialStates":["CDATA section state"],
+"input":"/",
+"output":[["Character", "/"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"0",
+"initialStates":["CDATA section state"],
+"input":"0",
+"output":[["Character", "0"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"1",
+"initialStates":["CDATA section state"],
+"input":"1",
+"output":[["Character", "1"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"9",
+"initialStates":["CDATA section state"],
+"input":"9",
+"output":[["Character", "9"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":";",
+"initialStates":["CDATA section state"],
+"input":";",
+"output":[["Character", ";"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":";=",
+"initialStates":["CDATA section state"],
+"input":";=",
+"output":[["Character", ";="]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";>",
+"initialStates":["CDATA section state"],
+"input":";>",
+"output":[["Character", ";>"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";?",
+"initialStates":["CDATA section state"],
+"input":";?",
+"output":[["Character", ";?"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";@",
+"initialStates":["CDATA section state"],
+"input":";@",
+"output":[["Character", ";@"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";A",
+"initialStates":["CDATA section state"],
+"input":";A",
+"output":[["Character", ";A"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";B",
+"initialStates":["CDATA section state"],
+"input":";B",
+"output":[["Character", ";B"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";Y",
+"initialStates":["CDATA section state"],
+"input":";Y",
+"output":[["Character", ";Y"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";Z",
+"initialStates":["CDATA section state"],
+"input":";Z",
+"output":[["Character", ";Z"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";`",
+"initialStates":["CDATA section state"],
+"input":";`",
+"output":[["Character", ";`"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";a",
+"initialStates":["CDATA section state"],
+"input":";a",
+"output":[["Character", ";a"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";b",
+"initialStates":["CDATA section state"],
+"input":";b",
+"output":[["Character", ";b"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";y",
+"initialStates":["CDATA section state"],
+"input":";y",
+"output":[["Character", ";y"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";z",
+"initialStates":["CDATA section state"],
+"input":";z",
+"output":[["Character", ";z"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";{",
+"initialStates":["CDATA section state"],
+"input":";{",
+"output":[["Character", ";{"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]},
+
+{"description":";\\uDBC0\\uDC00",
+"initialStates":["CDATA section state"],
+"input":";\uDBC0\uDC00",
+"output":[["Character", ";\uDBC0\uDC00"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 4 }
+]},
+
+{"description":"=",
+"initialStates":["CDATA section state"],
+"input":"=",
+"output":[["Character", "="]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":">",
+"initialStates":["CDATA section state"],
+"input":">",
+"output":[["Character", ">"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"?",
+"initialStates":["CDATA section state"],
+"input":"?",
+"output":[["Character", "?"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"@",
+"initialStates":["CDATA section state"],
+"input":"@",
+"output":[["Character", "@"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"A",
+"initialStates":["CDATA section state"],
+"input":"A",
+"output":[["Character", "A"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"B",
+"initialStates":["CDATA section state"],
+"input":"B",
+"output":[["Character", "B"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"Y",
+"initialStates":["CDATA section state"],
+"input":"Y",
+"output":[["Character", "Y"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"Z",
+"initialStates":["CDATA section state"],
+"input":"Z",
+"output":[["Character", "Z"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"`",
+"initialStates":["CDATA section state"],
+"input":"`",
+"output":[["Character", "`"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"a",
+"initialStates":["CDATA section state"],
+"input":"a",
+"output":[["Character", "a"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"b",
+"initialStates":["CDATA section state"],
+"input":"b",
+"output":[["Character", "b"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"y",
+"initialStates":["CDATA section state"],
+"input":"y",
+"output":[["Character", "y"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"z",
+"initialStates":["CDATA section state"],
+"input":"z",
+"output":[["Character", "z"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"{",
+"initialStates":["CDATA section state"],
+"input":"{",
+"output":[["Character", "{"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 2 }
+]},
+
+{"description":"\\uDBC0\\uDC00",
+"initialStates":["CDATA section state"],
+"input":"\uDBC0\uDC00",
+"output":[["Character", "\uDBC0\uDC00"]],
+"errors":[
+    { "code": "eof-in-cdata", "line": 1, "col": 3 }
+]}
+
+    ]
+}

--- a/tokenizer/domjs.test
+++ b/tokenizer/domjs.test
@@ -35,13 +35,6 @@
             ]
         },
         {
-            "description":"NUL in CDATA section",
-            "doubleEscaped":true,
-            "initialStates":["CDATA section state"],
-            "input":"\\u0000]]>",
-            "output":[["Character", "\\u0000"]]
-        },
-        {
            "description":"NUL in script HTML comment",
            "doubleEscaped":true,
            "initialStates":["Script data state"],
@@ -278,51 +271,6 @@
             "output":[["Comment", "[CDATA[foo]]"]],
             "errors":[
                 { "code": "cdata-in-html-content", "line": 1, "col": 9 }
-            ]
-        },
-        {
-            "description":"CDATA content",
-            "input":"foo&#32;]]>",
-            "initialStates":["CDATA section state"],
-            "output":[["Character", "foo&#32;"]]
-        },
-        {
-            "description":"CDATA followed by HTML content",
-            "input":"foo&#32;]]>&#32;",
-            "initialStates":["CDATA section state"],
-            "output":[["Character", "foo&#32; "]]
-        },
-        {
-            "description":"CDATA with extra bracket",
-            "input":"foo]]]>",
-            "initialStates":["CDATA section state"],
-            "output":[["Character", "foo]"]]
-        },
-        {
-            "description":"CDATA without end marker",
-            "input":"foo",
-            "initialStates":["CDATA section state"],
-            "output":[["Character", "foo"]],
-            "errors":[
-                { "code": "eof-in-cdata", "line": 1, "col": 4 }
-            ]
-        },
-        {
-            "description":"CDATA with single bracket ending",
-            "input":"foo]",
-            "initialStates":["CDATA section state"],
-            "output":[["Character", "foo]"]],
-            "errors":[
-                { "code": "eof-in-cdata", "line": 1, "col": 5 }
-            ]
-        },
-        {
-            "description":"CDATA with two brackets ending",
-            "input":"foo]]",
-            "initialStates":["CDATA section state"],
-            "output":[["Character", "foo]]"]],
-            "errors":[
-                { "code": "eof-in-cdata", "line": 1, "col": 6 }
             ]
         },
         {

--- a/tokenizer/test3.test
+++ b/tokenizer/test3.test
@@ -5,39 +5,15 @@
 "input":"",
 "output":[]},
 
-{"description":"[empty]",
-"initialStates":["CDATA section state"],
-"input":"",
-"output":[],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 1 }
-]},
-
 {"description":"\\u0009",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"\u0009",
 "output":[["Character", "\u0009"]]},
 
-{"description":"\\u0009",
-"initialStates":["CDATA section state"],
-"input":"\u0009",
-"output":[["Character", "\u0009"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"\\u000A",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"\u000A",
 "output":[["Character", "\u000A"]]},
-
-{"description":"\\u000A",
-"initialStates":["CDATA section state"],
-"input":"\u000A",
-"output":[["Character", "\u000A"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 2, "col": 1 }
-]},
 
 {"description":"\\u000B",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
@@ -47,404 +23,155 @@
     { "code": "control-character-in-input-stream", "line": 1, "col": 1 }
 ]},
 
-{"description":"\\u000B",
-"initialStates":["CDATA section state"],
-"input":"\u000B",
-"output":[["Character", "\u000B"]],
-"errors":[
-    { "code": "control-character-in-input-stream", "line": 1, "col": 1 },
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"\\u000C",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"\u000C",
 "output":[["Character", "\u000C"]]},
-
-{"description":"\\u000C",
-"initialStates":["CDATA section state"],
-"input":"\u000C",
-"output":[["Character", "\u000C"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":" ",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":" ",
 "output":[["Character", " "]]},
 
-{"description":" ",
-"initialStates":["CDATA section state"],
-"input":" ",
-"output":[["Character", " "]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"!",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"!",
 "output":[["Character", "!"]]},
-
-{"description":"!",
-"initialStates":["CDATA section state"],
-"input":"!",
-"output":[["Character", "!"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"\"",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"\"",
 "output":[["Character", "\""]]},
 
-{"description":"\"",
-"initialStates":["CDATA section state"],
-"input":"\"",
-"output":[["Character", "\""]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"%",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"%",
 "output":[["Character", "%"]]},
-
-{"description":"%",
-"initialStates":["CDATA section state"],
-"input":"%",
-"output":[["Character", "%"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"&",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"&",
 "output":[["Character", "&"]]},
 
-{"description":"&",
-"initialStates":["CDATA section state"],
-"input":"&",
-"output":[["Character", "&"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"'",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"'",
 "output":[["Character", "'"]]},
-
-{"description":"'",
-"initialStates":["CDATA section state"],
-"input":"'",
-"output":[["Character", "'"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":",",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":",",
 "output":[["Character", ","]]},
 
-{"description":",",
-"initialStates":["CDATA section state"],
-"input":",",
-"output":[["Character", ","]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"-",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"-",
 "output":[["Character", "-"]]},
-
-{"description":"-",
-"initialStates":["CDATA section state"],
-"input":"-",
-"output":[["Character", "-"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":".",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":".",
 "output":[["Character", "."]]},
 
-{"description":".",
-"initialStates":["CDATA section state"],
-"input":".",
-"output":[["Character", "."]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"/",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"/",
 "output":[["Character", "/"]]},
-
-{"description":"/",
-"initialStates":["CDATA section state"],
-"input":"/",
-"output":[["Character", "/"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"0",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"0",
 "output":[["Character", "0"]]},
 
-{"description":"0",
-"initialStates":["CDATA section state"],
-"input":"0",
-"output":[["Character", "0"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"1",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"1",
 "output":[["Character", "1"]]},
-
-{"description":"1",
-"initialStates":["CDATA section state"],
-"input":"1",
-"output":[["Character", "1"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"9",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"9",
 "output":[["Character", "9"]]},
 
-{"description":"9",
-"initialStates":["CDATA section state"],
-"input":"9",
-"output":[["Character", "9"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":";",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";",
 "output":[["Character", ";"]]},
-
-{"description":";",
-"initialStates":["CDATA section state"],
-"input":";",
-"output":[["Character", ";"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":";=",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";=",
 "output":[["Character", ";="]]},
 
-{"description":";=",
-"initialStates":["CDATA section state"],
-"input":";=",
-"output":[["Character", ";="]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";>",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";>",
 "output":[["Character", ";>"]]},
-
-{"description":";>",
-"initialStates":["CDATA section state"],
-"input":";>",
-"output":[["Character", ";>"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
 
 {"description":";?",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";?",
 "output":[["Character", ";?"]]},
 
-{"description":";?",
-"initialStates":["CDATA section state"],
-"input":";?",
-"output":[["Character", ";?"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";@",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";@",
 "output":[["Character", ";@"]]},
-
-{"description":";@",
-"initialStates":["CDATA section state"],
-"input":";@",
-"output":[["Character", ";@"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
 
 {"description":";A",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";A",
 "output":[["Character", ";A"]]},
 
-{"description":";A",
-"initialStates":["CDATA section state"],
-"input":";A",
-"output":[["Character", ";A"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";B",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";B",
 "output":[["Character", ";B"]]},
-
-{"description":";B",
-"initialStates":["CDATA section state"],
-"input":";B",
-"output":[["Character", ";B"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
 
 {"description":";Y",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";Y",
 "output":[["Character", ";Y"]]},
 
-{"description":";Y",
-"initialStates":["CDATA section state"],
-"input":";Y",
-"output":[["Character", ";Y"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";Z",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";Z",
 "output":[["Character", ";Z"]]},
-
-{"description":";Z",
-"initialStates":["CDATA section state"],
-"input":";Z",
-"output":[["Character", ";Z"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
 
 {"description":";`",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";`",
 "output":[["Character", ";`"]]},
 
-{"description":";`",
-"initialStates":["CDATA section state"],
-"input":";`",
-"output":[["Character", ";`"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";a",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";a",
 "output":[["Character", ";a"]]},
-
-{"description":";a",
-"initialStates":["CDATA section state"],
-"input":";a",
-"output":[["Character", ";a"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
 
 {"description":";b",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";b",
 "output":[["Character", ";b"]]},
 
-{"description":";b",
-"initialStates":["CDATA section state"],
-"input":";b",
-"output":[["Character", ";b"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";y",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";y",
 "output":[["Character", ";y"]]},
-
-{"description":";y",
-"initialStates":["CDATA section state"],
-"input":";y",
-"output":[["Character", ";y"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
 
 {"description":";z",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";z",
 "output":[["Character", ";z"]]},
 
-{"description":";z",
-"initialStates":["CDATA section state"],
-"input":";z",
-"output":[["Character", ";z"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";{",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";{",
 "output":[["Character", ";{"]]},
 
-{"description":";{",
-"initialStates":["CDATA section state"],
-"input":";{",
-"output":[["Character", ";{"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]},
-
 {"description":";\\uDBC0\\uDC00",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":";\uDBC0\uDC00",
 "output":[["Character", ";\uDBC0\uDC00"]]},
-
-{"description":";\\uDBC0\\uDC00",
-"initialStates":["CDATA section state"],
-"input":";\uDBC0\uDC00",
-"output":[["Character", ";\uDBC0\uDC00"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 4 }
-]},
 
 {"description":"<",
 "input":"<",
@@ -11040,194 +10767,74 @@
 "input":"=",
 "output":[["Character", "="]]},
 
-{"description":"=",
-"initialStates":["CDATA section state"],
-"input":"=",
-"output":[["Character", "="]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":">",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":">",
 "output":[["Character", ">"]]},
-
-{"description":">",
-"initialStates":["CDATA section state"],
-"input":">",
-"output":[["Character", ">"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"?",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"?",
 "output":[["Character", "?"]]},
 
-{"description":"?",
-"initialStates":["CDATA section state"],
-"input":"?",
-"output":[["Character", "?"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"@",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"@",
 "output":[["Character", "@"]]},
-
-{"description":"@",
-"initialStates":["CDATA section state"],
-"input":"@",
-"output":[["Character", "@"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"A",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"A",
 "output":[["Character", "A"]]},
 
-{"description":"A",
-"initialStates":["CDATA section state"],
-"input":"A",
-"output":[["Character", "A"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"B",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"B",
 "output":[["Character", "B"]]},
-
-{"description":"B",
-"initialStates":["CDATA section state"],
-"input":"B",
-"output":[["Character", "B"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"Y",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"Y",
 "output":[["Character", "Y"]]},
 
-{"description":"Y",
-"initialStates":["CDATA section state"],
-"input":"Y",
-"output":[["Character", "Y"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"Z",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"Z",
 "output":[["Character", "Z"]]},
-
-{"description":"Z",
-"initialStates":["CDATA section state"],
-"input":"Z",
-"output":[["Character", "Z"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"`",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"`",
 "output":[["Character", "`"]]},
 
-{"description":"`",
-"initialStates":["CDATA section state"],
-"input":"`",
-"output":[["Character", "`"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"a",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"a",
 "output":[["Character", "a"]]},
-
-{"description":"a",
-"initialStates":["CDATA section state"],
-"input":"a",
-"output":[["Character", "a"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"b",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"b",
 "output":[["Character", "b"]]},
 
-{"description":"b",
-"initialStates":["CDATA section state"],
-"input":"b",
-"output":[["Character", "b"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"y",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"y",
 "output":[["Character", "y"]]},
-
-{"description":"y",
-"initialStates":["CDATA section state"],
-"input":"y",
-"output":[["Character", "y"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
 
 {"description":"z",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"z",
 "output":[["Character", "z"]]},
 
-{"description":"z",
-"initialStates":["CDATA section state"],
-"input":"z",
-"output":[["Character", "z"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"{",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"{",
 "output":[["Character", "{"]]},
 
-{"description":"{",
-"initialStates":["CDATA section state"],
-"input":"{",
-"output":[["Character", "{"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 2 }
-]},
-
 {"description":"\\uDBC0\\uDC00",
 "initialStates":["Data state", "PLAINTEXT state", "RCDATA state", "RAWTEXT state", "Script data state"],
 "input":"\uDBC0\uDC00",
-"output":[["Character", "\uDBC0\uDC00"]]},
-
-{"description":"\\uDBC0\\uDC00",
-"initialStates":["CDATA section state"],
-"input":"\uDBC0\uDC00",
-"output":[["Character", "\uDBC0\uDC00"]],
-"errors":[
-    { "code": "eof-in-cdata", "line": 1, "col": 3 }
-]}
+"output":[["Character", "\uDBC0\uDC00"]]}
 
 ]}


### PR DESCRIPTION
All other initial states are referenced outside the section 13.2.5 Tokenization[1] that describes the tokenizer state machine.

It's therefore reasonable to consider the 'CDATA section state' an implementation detail and as such a tokenizer may choose to avoid exposing it in it's public API.

In that scenario while all other tests could be integration tests that solely use the public API, the tests for the 'CDATA section state' would need to be performed internally rather than externally.

This commit moves all the 'CDATA section state' tests into a new separate cdataSection.test file to faciliate such testing.

[1]: https://html.spec.whatwg.org/multipage/parsing.html#tokenization