### PR TITLE
Update tests for relaxed <select> parser

### DIFF
--- a/tree-construction/menuitem-element.dat
+++ b/tree-construction/menuitem-element.dat
@@ -161,6 +161,7 @@
 #data
 <!DOCTYPE html><select><menuitem></select>
 #errors
+1:34: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body, select, menuitem.
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/menuitem-element.dat
+++ b/tree-construction/menuitem-element.dat
@@ -161,13 +161,13 @@
 #data
 <!DOCTYPE html><select><menuitem></select>
 #errors
-33: Stray start tag “menuitem”.
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
+|       <menuitem>
 
 #data
 <!DOCTYPE html><option><menuitem>

--- a/tree-construction/tables01.dat
+++ b/tree-construction/tables01.dat
@@ -100,8 +100,11 @@
 #data
 <table><select><option>3</select></table>
 #errors
-(1,7): expected-doctype-but-got-start-tag
-(1,15): unexpected-start-tag-implies-table-voodoo
+1:1: ERROR: Expected a doctype token
+1:8: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
+1:16: ERROR: Start tag 'option' isn't allowed here. Currently open tags: html, body, table, select.
+1:24: ERROR: Character tokens aren't legal here
+1:25: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body, table, select, option.
 #document
 | <html>
 |   <head>
@@ -114,12 +117,11 @@
 #data
 <table><select><table></table></select></table>
 #errors
-(1,7): expected-doctype-but-got-start-tag
-(1,15): unexpected-start-tag-implies-table-voodoo
-(1,22): unexpected-table-element-start-tag-in-select-in-table
-(1,22): unexpected-start-tag-implies-end-tag
-(1,39): unexpected-end-tag
-(1,47): unexpected-end-tag
+1:1: ERROR: Expected a doctype token
+1:8: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
+1:16: ERROR: Start tag 'table' isn't allowed here. Currently open tags: html, body, table, select.
+1:31: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body.
+1:40: ERROR: End tag 'table' isn't allowed here. Currently open tags: html, body.
 #document
 | <html>
 |   <head>
@@ -131,9 +133,8 @@
 #data
 <table><select></table>
 #errors
-(1,7): expected-doctype-but-got-start-tag
-(1,15): unexpected-start-tag-implies-table-voodoo
-(1,23): unexpected-table-element-end-tag-in-select-in-table
+1:1: ERROR: Expected a doctype token
+1:8: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
 #document
 | <html>
 |   <head>
@@ -144,9 +145,10 @@
 #data
 <table><select><option>A<tr><td>B</td></tr></table>
 #errors
-(1,7): expected-doctype-but-got-start-tag
-(1,15): unexpected-start-tag-implies-table-voodoo
-(1,28): unexpected-table-element-start-tag-in-select-in-table
+1:1: ERROR: Expected a doctype token
+1:8: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
+1:16: ERROR: Start tag 'option' isn't allowed here. Currently open tags: html, body, table, select.
+1:24: ERROR: Character tokens aren't legal here
 #document
 | <html>
 |   <head>
@@ -292,7 +294,6 @@
 1:13: 'svg' tag isn't allowed here. Currently open tags: html, body, div, table.
 1:33: 'select' tag isn't allowed here. Currently open tags: html, body, div, table, svg, foreignobject.
 1:41: 'table' tag isn't allowed here. Currently open tags: html, body, div, table, svg, foreignobject, select.
-1:41: 'table' tag isn't allowed here. Currently open tags: html, body, div, table, svg, foreignobject.
 1:48: 's' tag isn't allowed here. Currently open tags: html, body, div, table.
 1:51: Premature end of file. Currently open tags: html, body, div, table, s.
 #document

--- a/tree-construction/tests1.dat
+++ b/tree-construction/tests1.dat
@@ -367,9 +367,8 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <b>
 |         <option>
 |     <b>
-|       <select>
-|         <option>
-|       "X"
+|       <option>
+|     "X"
 
 #data
 <a><table><td><a><table></table><a></tr><a></table><b>X</b>C<a>Y
@@ -1546,8 +1545,7 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <b>
 |         <option>
 |     <b>
-|       <select>
-|         <option>
+|       <option>
 
 #data
 <html><head><title></title><body></body></html>

--- a/tree-construction/tests1.dat
+++ b/tree-construction/tests1.dat
@@ -363,10 +363,9 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <b>
 |         <option>
 |     <b>
-|     <select>
-|       <b>
+|       <select>
 |         <option>
-|     "X"
+|       "X"
 
 #data
 <a><table><td><a><table></table><a></tr><a></table><b>X</b>C<a>Y
@@ -1539,8 +1538,7 @@ Line1<br>Line2<br>Line3<br>Line4
 |       <b>
 |         <option>
 |     <b>
-|     <select>
-|       <b>
+|       <select>
 |         <option>
 
 #data

--- a/tree-construction/tests1.dat
+++ b/tree-construction/tests1.dat
@@ -355,19 +355,18 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <select><b><option><select><option></b></select>X
 #errors
-(1,8): expected-doctype-but-got-start-tag
-(1,11): unexpected-start-tag-in-select
-(1,27): unexpected-select-in-select
-(1,39): unexpected-end-tag
-(1,48): unexpected-end-tag
 #document
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|       <option>
-|     <option>
-|       "X"
+|       <b>
+|         <option>
+|     <b>
+|     <select>
+|       <b>
+|         <option>
+|     "X"
 
 #data
 <a><table><td><a><table></table><a></tr><a></table><b>X</b>C<a>Y
@@ -1532,18 +1531,17 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <select><b><option><select><option></b></select>
 #errors
-(1,8): expected-doctype-but-got-start-tag
-(1,11): unexpected-start-tag-in-select
-(1,27): unexpected-select-in-select
-(1,39): unexpected-end-tag
-(1,48): unexpected-end-tag
 #document
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|       <option>
-|     <option>
+|       <b>
+|         <option>
+|     <b>
+|     <select>
+|       <b>
+|         <option>
 
 #data
 <html><head><title></title><body></body></html>

--- a/tree-construction/tests1.dat
+++ b/tree-construction/tests1.dat
@@ -355,6 +355,10 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <select><b><option><select><option></b></select>X
 #errors
+1:1: ERROR: Expected a doctype token
+1:20: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, b, option.
+1:36: ERROR: End tag 'b' isn't allowed here. Currently open tags: html, body, b, select, option.
+1:50: ERROR: Premature end of file. Currently open tags: html, body, b.
 #document
 | <html>
 |   <head>
@@ -1530,6 +1534,10 @@ Line1<br>Line2<br>Line3<br>Line4
 #data
 <select><b><option><select><option></b></select>
 #errors
+1:1: ERROR: Expected a doctype token
+1:20: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, b, option.
+1:36: ERROR: End tag 'b' isn't allowed here. Currently open tags: html, body, b, select, option.
+1:49: ERROR: Premature end of file. Currently open tags: html, body, b.
 #document
 | <html>
 |   <head>

--- a/tree-construction/tests10.dat
+++ b/tree-construction/tests10.dat
@@ -35,20 +35,17 @@
 #data
 <!DOCTYPE html><body><select><svg></svg></select>
 #errors
-(1,34) unexpected-start-tag-in-select
-(1,40) unexpected-end-tag-in-select
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
+|       <svg svg>
 
 #data
 <!DOCTYPE html><body><select><option><svg></svg></option></select>
 #errors
-(1,42) unexpected-start-tag-in-select
-(1,48) unexpected-end-tag-in-select
 #document
 | <!DOCTYPE html>
 | <html>
@@ -56,6 +53,7 @@
 |   <body>
 |     <select>
 |       <option>
+|         <svg svg>
 
 #data
 <!DOCTYPE html><body><table><svg></svg></table>
@@ -261,13 +259,6 @@
 #data
 <!DOCTYPE html><body><table><tr><td><select><svg><g>foo</g><g>bar</g><p>baz</table><p>quux
 #errors
-(1,49) unexpected-start-tag-in-select
-(1,52) unexpected-start-tag-in-select
-(1,59) unexpected-end-tag-in-select
-(1,62) unexpected-start-tag-in-select
-(1,69) unexpected-end-tag-in-select
-(1,72) unexpected-start-tag-in-select
-(1,83) unexpected-table-element-end-tag-in-select-in-table
 #document
 | <!DOCTYPE html>
 | <html>
@@ -278,28 +269,32 @@
 |         <tr>
 |           <td>
 |             <select>
-|               "foobarbaz"
+|               <svg svg>
+|                 <svg g>
+|                   "foo"
+|                 <svg g>
+|                   "bar"
+|               <p>
+|                 "baz"
 |     <p>
 |       "quux"
 
 #data
 <!DOCTYPE html><body><table><select><svg><g>foo</g><g>bar</g><p>baz</table><p>quux
 #errors
-(1,36) unexpected-start-tag-implies-table-voodoo
-(1,41) unexpected-start-tag-in-select
-(1,44) unexpected-start-tag-in-select
-(1,51) unexpected-end-tag-in-select
-(1,54) unexpected-start-tag-in-select
-(1,61) unexpected-end-tag-in-select
-(1,64) unexpected-start-tag-in-select
-(1,75) unexpected-table-element-end-tag-in-select-in-table
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|       "foobarbaz"
+|       <svg svg>
+|         <svg g>
+|           "foo"
+|         <svg g>
+|           "bar"
+|       <p>
+|         "baz"
 |     <table>
 |     <p>
 |       "quux"

--- a/tree-construction/tests10.dat
+++ b/tree-construction/tests10.dat
@@ -259,6 +259,8 @@
 #data
 <!DOCTYPE html><body><table><tr><td><select><svg><g>foo</g><g>bar</g><p>baz</table><p>quux
 #errors
+1:70: ERROR: Start tag 'p' isn't allowed here. Currently open tags: html, body, table, tbody, tr, td, select, svg.
+1:76: ERROR: End tag 'table' isn't allowed here. Currently open tags: html, body, table, tbody, tr, td, select.
 #document
 | <!DOCTYPE html>
 | <html>
@@ -282,6 +284,13 @@
 #data
 <!DOCTYPE html><body><table><select><svg><g>foo</g><g>bar</g><p>baz</table><p>quux
 #errors
+1:29: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
+1:37: ERROR: Start tag 'svg' isn't allowed here. Currently open tags: html, body, table, select.
+1:62: ERROR: Start tag 'p' isn't allowed here. Currently open tags: html, body, table, select, svg.
+1:62: ERROR: Start tag 'p' isn't allowed here. Currently open tags: html, body, table, select.
+1:65: ERROR: Character tokens aren't legal here
+1:66: ERROR: Character tokens aren't legal here
+1:67: ERROR: Character tokens aren't legal here
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests17.dat
+++ b/tree-construction/tests17.dat
@@ -1,9 +1,8 @@
 #data
 <!doctype html><table><tbody><select><tr>
 #errors
-(1,37): unexpected-start-tag-implies-table-voodoo
-(1,41): unexpected-table-element-start-tag-in-select-in-table
-(1,41): eof-in-table
+(1,30): unexpected-start-tag
+(1,42): premature-eof
 #document
 | <!DOCTYPE html>
 | <html>
@@ -17,9 +16,8 @@
 #data
 <!doctype html><table><tr><select><td>
 #errors
-(1,34): unexpected-start-tag-implies-table-voodoo
-(1,38): unexpected-table-element-start-tag-in-select-in-table
-(1,38): expected-closing-tag-but-got-eof
+(1,27): unexpected-start-tag
+(1,39): premature-eof
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests18.dat
+++ b/tree-construction/tests18.dat
@@ -227,34 +227,27 @@
 #data
 <!doctype html><select><plaintext></plaintext>X
 #errors
-34: Stray start tag “plaintext”.
-46: Stray end tag “plaintext”.
-47: End of file seen and there were open elements.
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|       "X"
+|       <plaintext>
+|         "</plaintext>X"
 
 #data
 <!doctype html><table><select><plaintext>a<caption>b
 #errors
-30: Start tag “select” seen in “table”.
-41: Stray start tag “plaintext”.
-51: “caption” start tag with “select” open.
-52: End of file seen and there were open elements.
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|       "a"
+|       <plaintext>
+|         "a<caption>b"
 |     <table>
-|       <caption>
-|         "b"
 
 #data
 <!doctype html><template><plaintext>a</template>b

--- a/tree-construction/tests18.dat
+++ b/tree-construction/tests18.dat
@@ -227,6 +227,7 @@
 #data
 <!doctype html><select><plaintext></plaintext>X
 #errors
+1:48: ERROR: Premature end of file. Currently open tags: html, body, select, plaintext.
 #document
 | <!DOCTYPE html>
 | <html>
@@ -239,6 +240,20 @@
 #data
 <!doctype html><table><select><plaintext>a<caption>b
 #errors
+1:23: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
+1:31: ERROR: Start tag 'plaintext' isn't allowed here. Currently open tags: html, body, table, select.
+1:42: ERROR: Character tokens aren't legal here
+1:43: ERROR: Character tokens aren't legal here
+1:44: ERROR: Character tokens aren't legal here
+1:45: ERROR: Character tokens aren't legal here
+1:46: ERROR: Character tokens aren't legal here
+1:47: ERROR: Character tokens aren't legal here
+1:48: ERROR: Character tokens aren't legal here
+1:49: ERROR: Character tokens aren't legal here
+1:50: ERROR: Character tokens aren't legal here
+1:51: ERROR: Character tokens aren't legal here
+1:52: ERROR: Character tokens aren't legal here
+1:53: ERROR: Premature end of file. Currently open tags: html, body, table, select, plaintext.
 #document
 | <!DOCTYPE html>
 | <html>
@@ -439,8 +454,11 @@
 #data
 <!doctype html><table><select><script></style></script>abc
 #errors
-(1,30): unexpected-start-tag-implies-table-voodoo
-(1,58): eof-in-select
+1:23: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
+1:56: ERROR: Character tokens aren't legal here
+1:57: ERROR: Character tokens aren't legal here
+1:58: ERROR: Character tokens aren't legal here
+1:59: ERROR: Premature end of file. Currently open tags: html, body, table, select.
 #document
 | <!DOCTYPE html>
 | <html>
@@ -455,8 +473,11 @@
 #data
 <!doctype html><table><tr><select><script></style></script>abc
 #errors
-(1,34): unexpected-start-tag-implies-table-voodoo
-(1,62): eof-in-select
+1:27: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table, tbody, tr.
+1:60: ERROR: Character tokens aren't legal here
+1:61: ERROR: Character tokens aren't legal here
+1:62: ERROR: Character tokens aren't legal here
+1:63: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, select.
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests2.dat
+++ b/tree-construction/tests2.dat
@@ -500,6 +500,8 @@
 #data
 <!DOCTYPE html><select><optgroup><option></optgroup><option><select><option>
 #errors
+1:61: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:77: ERROR: Premature end of file. Currently open tags: html, body, select, option.
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests2.dat
+++ b/tree-construction/tests2.dat
@@ -511,8 +511,7 @@
 |       <optgroup>
 |         <option>
 |       <option>
-|     <select>
-|       <option>
+|     <option>
 
 #data
 <!DOCTYPE html><select><optgroup><option><optgroup>

--- a/tree-construction/tests2.dat
+++ b/tree-construction/tests2.dat
@@ -500,7 +500,6 @@
 #data
 <!DOCTYPE html><select><optgroup><option></optgroup><option><select><option>
 #errors
-(1,68): unexpected-select-in-select
 #document
 | <!DOCTYPE html>
 | <html>
@@ -510,7 +509,8 @@
 |       <optgroup>
 |         <option>
 |       <option>
-|     <option>
+|     <select>
+|       <option>
 
 #data
 <!DOCTYPE html><select><optgroup><option><optgroup>

--- a/tree-construction/tests2.dat
+++ b/tree-construction/tests2.dat
@@ -501,7 +501,6 @@
 <!DOCTYPE html><select><optgroup><option></optgroup><option><select><option>
 #errors
 1:61: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
-1:77: ERROR: Premature end of file. Currently open tags: html, body, select, option.
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests7.dat
+++ b/tree-construction/tests7.dat
@@ -200,27 +200,26 @@ X</listing>
 #data
 <!doctype html><select><input>X
 #errors
-(1,30): unexpected-input-in-select
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|     <input>
-|     "X"
+|       <input>
+|       "X"
 
 #data
 <!doctype html><select><select>X
 #errors
-(1,31): unexpected-select-in-select
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|     "X"
+|     <select>
+|       "X"
 
 #data
 <!doctype html><table><input type=hidDEN></table>
@@ -443,11 +442,9 @@ A<table><tr> B</tr> </em>C</table>
 #data
 <select><keygen>
 #errors
-(1,8): expected-doctype-but-got-start-tag
-(1,16): unexpected-input-in-select
 #document
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|     <keygen>
+|       <keygen>

--- a/tree-construction/tests7.dat
+++ b/tree-construction/tests7.dat
@@ -214,7 +214,6 @@ X</listing>
 <!doctype html><select><select>X
 #errors
 1:24: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select.
-1:33: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests7.dat
+++ b/tree-construction/tests7.dat
@@ -200,6 +200,7 @@ X</listing>
 #data
 <!doctype html><select><input>X
 #errors
+1:32: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <!DOCTYPE html>
 | <html>
@@ -212,6 +213,8 @@ X</listing>
 #data
 <!doctype html><select><select>X
 #errors
+1:24: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select.
+1:33: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <!DOCTYPE html>
 | <html>
@@ -442,6 +445,8 @@ A<table><tr> B</tr> </em>C</table>
 #data
 <select><keygen>
 #errors
+1:1: ERROR: Expected a doctype token
+1:17: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <html>
 |   <head>

--- a/tree-construction/tests7.dat
+++ b/tree-construction/tests7.dat
@@ -221,8 +221,7 @@ X</listing>
 |   <head>
 |   <body>
 |     <select>
-|     <select>
-|       "X"
+|     "X"
 
 #data
 <!doctype html><table><input type=hidDEN></table>

--- a/tree-construction/tests7.dat
+++ b/tree-construction/tests7.dat
@@ -207,8 +207,8 @@ X</listing>
 |   <head>
 |   <body>
 |     <select>
-|       <input>
-|       "X"
+|     <input>
+|     "X"
 
 #data
 <!doctype html><select><select>X

--- a/tree-construction/tests9.dat
+++ b/tree-construction/tests9.dat
@@ -48,20 +48,17 @@
 #data
 <!DOCTYPE html><body><select><math></math></select>
 #errors
-(1,35) unexpected-start-tag-in-select
-(1,42) unexpected-end-tag-in-select
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
+|       <math math>
 
 #data
 <!DOCTYPE html><body><select><option><math></math></option></select>
 #errors
-(1,43) unexpected-start-tag-in-select
-(1,50) unexpected-end-tag-in-select
 #document
 | <!DOCTYPE html>
 | <html>
@@ -69,6 +66,7 @@
 |   <body>
 |     <select>
 |       <option>
+|         <math math>
 
 #data
 <!DOCTYPE html><body><table><math></math></table>
@@ -301,13 +299,6 @@
 #data
 <!DOCTYPE html><body><table><tr><td><select><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux
 #errors
-(1,50) unexpected-start-tag-in-select
-(1,54) unexpected-start-tag-in-select
-(1,62) unexpected-end-tag-in-select
-(1,66) unexpected-start-tag-in-select
-(1,74) unexpected-end-tag-in-select
-(1,77) unexpected-start-tag-in-select
-(1,88) unexpected-table-element-end-tag-in-select-in-table
 #document
 | <!DOCTYPE html>
 | <html>
@@ -318,28 +309,32 @@
 |         <tr>
 |           <td>
 |             <select>
-|               "foobarbaz"
+|               <math math>
+|                 <math mi>
+|                   "foo"
+|                 <math mi>
+|                   "bar"
+|               <p>
+|                 "baz"
 |     <p>
 |       "quux"
 
 #data
 <!DOCTYPE html><body><table><select><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux
 #errors
-(1,36) unexpected-start-tag-implies-table-voodoo
-(1,42) unexpected-start-tag-in-select
-(1,46) unexpected-start-tag-in-select
-(1,54) unexpected-end-tag-in-select
-(1,58) unexpected-start-tag-in-select
-(1,66) unexpected-end-tag-in-select
-(1,69) unexpected-start-tag-in-select
-(1,80) unexpected-table-element-end-tag-in-select-in-table
 #document
 | <!DOCTYPE html>
 | <html>
 |   <head>
 |   <body>
 |     <select>
-|       "foobarbaz"
+|       <math math>
+|         <math mi>
+|           "foo"
+|         <math mi>
+|           "bar"
+|       <p>
+|         "baz"
 |     <table>
 |     <p>
 |       "quux"

--- a/tree-construction/tests9.dat
+++ b/tree-construction/tests9.dat
@@ -299,6 +299,8 @@
 #data
 <!DOCTYPE html><body><table><tr><td><select><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux
 #errors
+1:75: ERROR: Start tag 'p' isn't allowed here. Currently open tags: html, body, table, tbody, tr, td, select, math.
+1:81: ERROR: End tag 'table' isn't allowed here. Currently open tags: html, body, table, tbody, tr, td, select.
 #document
 | <!DOCTYPE html>
 | <html>
@@ -322,6 +324,19 @@
 #data
 <!DOCTYPE html><body><table><select><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux
 #errors
+1:29: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, table.
+1:37: ERROR: Start tag 'math' isn't allowed here. Currently open tags: html, body, table, select.
+1:47: ERROR: Character tokens aren't legal here
+1:48: ERROR: Character tokens aren't legal here
+1:49: ERROR: Character tokens aren't legal here
+1:59: ERROR: Character tokens aren't legal here
+1:60: ERROR: Character tokens aren't legal here
+1:61: ERROR: Character tokens aren't legal here
+1:67: ERROR: Start tag 'p' isn't allowed here. Currently open tags: html, body, table, select, math.
+1:67: ERROR: Start tag 'p' isn't allowed here. Currently open tags: html, body, table, select.
+1:70: ERROR: Character tokens aren't legal here
+1:71: ERROR: Character tokens aren't legal here
+1:72: ERROR: Character tokens aren't legal here
 #document
 | <!DOCTYPE html>
 | <html>

--- a/tree-construction/tests_innerHTML_1.dat
+++ b/tree-construction/tests_innerHTML_1.dat
@@ -790,29 +790,29 @@ select
 #data
 <input><option>
 #errors
-(1,7): unexpected-input-in-select
 #document-fragment
 select
 #document
+| <input>
 | <option>
 
 #data
 <keygen><option>
 #errors
-(1,8): unexpected-input-in-select
 #document-fragment
 select
 #document
+| <keygen>
 | <option>
 
 #data
 <textarea><option>
 #errors
-(1,10): unexpected-input-in-select
 #document-fragment
 select
 #document
-| <option>
+| <textarea>
+|   "<option>"
 
 #data
 </html><!--abc-->

--- a/tree-construction/tests_innerHTML_1.dat
+++ b/tree-construction/tests_innerHTML_1.dat
@@ -808,6 +808,7 @@ select
 #data
 <textarea><option>
 #errors
+1:19: ERROR: Premature end of file. Currently open tags: html, textarea.
 #document-fragment
 select
 #document

--- a/tree-construction/webkit01.dat
+++ b/tree-construction/webkit01.dat
@@ -439,13 +439,9 @@ no-doctype
 #errors
 1:1: ERROR: Expected a doctype token
 1:18: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
-1:35: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
 1:52: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
-1:69: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
 1:86: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
-1:103: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
 1:120: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
-1:128: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <html>
 |   <head>

--- a/tree-construction/webkit01.dat
+++ b/tree-construction/webkit01.dat
@@ -437,6 +437,15 @@ no-doctype
 #data
 <select><option>A<select><option>B<select><option>C<select><option>D<select><option>E<select><option>F<select><option>G<select>
 #errors
+1:1: ERROR: Expected a doctype token
+1:18: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:35: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:52: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:69: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:86: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:103: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:120: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, option.
+1:128: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <html>
 |   <head>
@@ -527,12 +536,11 @@ no-doctype
 #data
 <kbd><table></kbd><col><select><tr>
 #errors
-(1,5): expected-doctype-but-got-start-tag
-(1,18): unexpected-end-tag-implies-table-voodoo
-(1,18): unexpected-end-tag
-(1,31): unexpected-start-tag-implies-table-voodoo
-(1,35): unexpected-table-element-start-tag-in-select-in-table
-(1,35): eof-in-table
+1:1: ERROR: Expected a doctype token
+1:13: ERROR: End tag 'kbd' isn't allowed here. Currently open tags: html, body, kbd, table.
+1:13: ERROR: End tag 'kbd' isn't allowed here. Currently open tags: html, body, kbd, table.
+1:24: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, kbd, table.
+1:36: ERROR: Premature end of file. Currently open tags: html, body, kbd, table, tbody, tr.
 #document
 | <html>
 |   <head>
@@ -548,12 +556,11 @@ no-doctype
 #data
 <kbd><table></kbd><col><select><tr></table><div>
 #errors
-(1,5): expected-doctype-but-got-start-tag
-(1,18): unexpected-end-tag-implies-table-voodoo
-(1,18): unexpected-end-tag
-(1,31): unexpected-start-tag-implies-table-voodoo
-(1,35): unexpected-table-element-start-tag-in-select-in-table
-(1,48): expected-closing-tag-but-got-eof
+1:1: ERROR: Expected a doctype token
+1:13: ERROR: End tag 'kbd' isn't allowed here. Currently open tags: html, body, kbd, table.
+1:13: ERROR: End tag 'kbd' isn't allowed here. Currently open tags: html, body, kbd, table.
+1:24: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, kbd, table.
+1:49: ERROR: Premature end of file. Currently open tags: html, body, kbd, div.
 #document
 | <html>
 |   <head>

--- a/tree-construction/webkit01.dat
+++ b/tree-construction/webkit01.dat
@@ -437,11 +437,6 @@ no-doctype
 #data
 <select><option>A<select><option>B<select><option>C<select><option>D<select><option>E<select><option>F<select><option>G<select>
 #errors
-(1,8): expected-doctype-but-got-start-tag
-(1,25): unexpected-select-in-select
-(1,59): unexpected-select-in-select
-(1,93): unexpected-select-in-select
-(1,127): unexpected-select-in-select
 #document
 | <html>
 |   <head>
@@ -449,21 +444,25 @@ no-doctype
 |     <select>
 |       <option>
 |         "A"
-|     <option>
-|       "B"
-|       <select>
-|         <option>
-|           "C"
-|     <option>
-|       "D"
-|       <select>
-|         <option>
-|           "E"
-|     <option>
-|       "F"
-|       <select>
-|         <option>
-|           "G"
+|     <select>
+|       <option>
+|         "B"
+|     <select>
+|       <option>
+|         "C"
+|     <select>
+|       <option>
+|         "D"
+|     <select>
+|       <option>
+|         "E"
+|     <select>
+|       <option>
+|         "F"
+|     <select>
+|       <option>
+|         "G"
+|     <select>
 
 #data
 <dd><dd><dt><dt><dd><li><li>

--- a/tree-construction/webkit01.dat
+++ b/tree-construction/webkit01.dat
@@ -453,25 +453,21 @@ no-doctype
 |     <select>
 |       <option>
 |         "A"
-|     <select>
-|       <option>
-|         "B"
-|     <select>
-|       <option>
-|         "C"
-|     <select>
-|       <option>
-|         "D"
-|     <select>
-|       <option>
-|         "E"
-|     <select>
-|       <option>
-|         "F"
-|     <select>
-|       <option>
-|         "G"
-|     <select>
+|     <option>
+|       "B"
+|       <select>
+|         <option>
+|           "C"
+|     <option>
+|       "D"
+|       <select>
+|         <option>
+|           "E"
+|     <option>
+|       "F"
+|       <select>
+|         <option>
+|           "G"
 
 #data
 <dd><dd><dt><dt><dd><li><li>

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -439,7 +439,7 @@ eof-in-math
 |     <select>
 |       <optgroup>
 |         <option>
-|         <hr>
+|       <hr>
 
 #data
 <select><optgroup><hr>
@@ -452,7 +452,7 @@ eof-in-math
 |   <body>
 |     <select>
 |       <optgroup>
-|         <hr>
+|       <hr>
 
 #data
 <select><option><optgroup><hr>
@@ -466,7 +466,7 @@ eof-in-math
 |     <select>
 |       <option>
 |       <optgroup>
-|         <hr>
+|       <hr>
 
 #data
 <table><tr><td><select><hr>
@@ -517,7 +517,7 @@ eof-in-math
 |             <select>
 |               <optgroup>
 |                 <option>
-|                 <hr>
+|               <hr>
 
 #data
 <table><tr><td><select><optgroup><hr>
@@ -534,7 +534,7 @@ eof-in-math
 |           <td>
 |             <select>
 |               <optgroup>
-|                 <hr>
+|               <hr>
 
 #data
 <table><tr><td><select><option><optgroup><hr>
@@ -552,7 +552,7 @@ eof-in-math
 |             <select>
 |               <option>
 |               <optgroup>
-|                 <hr>
+|               <hr>
 
 #data
 <select><div><i></div><option>option
@@ -567,8 +567,8 @@ eof-in-math
 |     <select>
 |       <div>
 |         <i>
-|       <option>
-|         <i>
+|       <i>
+|         <option>
 |           "option"
 
 #data
@@ -648,7 +648,6 @@ eof-in-math
 |   <body>
 |     <select>
 |       <button>
-|     <select>
 
 #data
 <select><button><div><select></select>
@@ -662,7 +661,6 @@ eof-in-math
 |     <select>
 |       <button>
 |         <div>
-|     <select>
 
 #data
 <select><div><option><img>option</option></div></select>

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -540,7 +540,8 @@ eof-in-math
 <table><tr><td><select><option><optgroup><hr>
 #errors
 1:1: ERROR: Expected a doctype token
-1:38: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select, optgroup.#document
+1:38: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select, optgroup.
+#document
 | <html>
 |   <head>
 |   <body>

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -555,3 +555,94 @@ eof-in-math
 |       <option>
 |         <i>
 |           "option"
+
+#data
+<div><i></div><option>option
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <div>
+|       <i>
+|     <i>
+|       <option>
+|         "option"
+
+#data
+<select><div>div 1</div><button>button</button><div>div 2</div><datalist><option>option</option></datalist><div>div 3</div></select>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <div>
+|         "div 1"
+|       <button>
+|         "button"
+|       <div>
+|         "div 2"
+|       <datalist>
+|         <option>
+|           "option"
+|       <div>
+|         "div 3"
+
+#data
+<select><button>button</select>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <button>
+|         "button"
+
+#data
+<select><datalist>datalist</select>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <datalist>
+|         "datalist"
+
+#data
+<select><button><select></select></button></select>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <button>
+|     <select>
+
+#data
+<select><button><div><select></select>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <button>
+|         <div>
+|     <select>
+
+#data
+<select><div><option><img>option</option></div></select>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <div>
+|         <option>
+|           <img>
+|           "option"

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -613,7 +613,6 @@ eof-in-math
 #errors
 1:1: ERROR: Expected a doctype token
 1:23: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body, select, button.
-1:32: ERROR: Premature end of file. Currently open tags: html, body, select, button.
 #document
 | <html>
 |   <head>
@@ -640,6 +639,7 @@ eof-in-math
 #errors
 1:1: ERROR: Expected a doctype token
 1:17: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, button.
+1:25: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body.
 1:34: ERROR: End tag 'button' isn't allowed here. Currently open tags: html, body.
 1:43: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body.
 #document
@@ -654,6 +654,7 @@ eof-in-math
 #errors
 1:1: ERROR: Expected a doctype token
 1:22: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, button, div.
+1:30: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body.
 #document
 | <html>
 |   <head>

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -309,6 +309,8 @@ div
 #data
 <option><XH<optgroup></optgroup>
 #errors
+1:22: ERROR: End tag 'optgroup' isn't allowed here. Currently open tags: html, option, xh<optgroup.
+1:33: ERROR: Premature end of file. Currently open tags: html, option, xh<optgroup.
 #document-fragment
 select
 #document
@@ -442,6 +444,8 @@ eof-in-math
 #data
 <select><optgroup><hr>
 #errors
+1:1: ERROR: Expected a doctype token
+1:23: ERROR: Premature end of file. Currently open tags: html, body, select, optgroup.
 #document
 | <html>
 |   <head>
@@ -453,6 +457,8 @@ eof-in-math
 #data
 <select><option><optgroup><hr>
 #errors
+1:1: ERROR: Expected a doctype token
+1:31: ERROR: Premature end of file. Currently open tags: html, body, select, optgroup.
 #document
 | <html>
 |   <head>
@@ -498,6 +504,8 @@ eof-in-math
 #data
 <table><tr><td><select><optgroup><option><hr>
 #errors
+1:1: ERROR: Expected a doctype token
+1:46: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select, optgroup.
 #document
 | <html>
 |   <head>
@@ -514,6 +522,8 @@ eof-in-math
 #data
 <table><tr><td><select><optgroup><hr>
 #errors
+1:1: ERROR: Expected a doctype token
+1:38: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select, optgroup.
 #document
 | <html>
 |   <head>
@@ -529,7 +539,8 @@ eof-in-math
 #data
 <table><tr><td><select><option><optgroup><hr>
 #errors
-#document
+1:1: ERROR: Expected a doctype token
+1:38: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select, optgroup.#document
 | <html>
 |   <head>
 |   <body>
@@ -545,6 +556,9 @@ eof-in-math
 #data
 <select><div><i></div><option>option
 #errors
+1:1: ERROR: Expected a doctype token
+1:17: ERROR: End tag 'div' isn't allowed here. Currently open tags: html, body, select, div, i.
+1:37: ERROR: Premature end of file. Currently open tags: html, body, select, option, i.
 #document
 | <html>
 |   <head>
@@ -559,6 +573,9 @@ eof-in-math
 #data
 <div><i></div><option>option
 #errors
+1:1: ERROR: Expected a doctype token
+1:9: ERROR: End tag 'div' isn't allowed here. Currently open tags: html, body, div, i.
+1:29: ERROR: Premature end of file. Currently open tags: html, body, i, option.
 #document
 | <html>
 |   <head>
@@ -572,6 +589,7 @@ eof-in-math
 #data
 <select><div>div 1</div><button>button</button><div>div 2</div><datalist><option>option</option></datalist><div>div 3</div></select>
 #errors
+1:1: ERROR: Expected a doctype token
 #document
 | <html>
 |   <head>
@@ -592,6 +610,9 @@ eof-in-math
 #data
 <select><button>button</select>
 #errors
+1:1: ERROR: Expected a doctype token
+1:23: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body, select, button.
+1:32: ERROR: Premature end of file. Currently open tags: html, body, select, button.
 #document
 | <html>
 |   <head>
@@ -603,6 +624,8 @@ eof-in-math
 #data
 <select><datalist>datalist</select>
 #errors
+1:1: ERROR: Expected a doctype token
+1:27: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body, select, datalist.
 #document
 | <html>
 |   <head>
@@ -614,6 +637,10 @@ eof-in-math
 #data
 <select><button><select></select></button></select>
 #errors
+1:1: ERROR: Expected a doctype token
+1:17: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, button.
+1:34: ERROR: End tag 'button' isn't allowed here. Currently open tags: html, body.
+1:43: ERROR: End tag 'select' isn't allowed here. Currently open tags: html, body.
 #document
 | <html>
 |   <head>
@@ -625,6 +652,8 @@ eof-in-math
 #data
 <select><button><div><select></select>
 #errors
+1:1: ERROR: Expected a doctype token
+1:22: ERROR: Start tag 'select' isn't allowed here. Currently open tags: html, body, select, button, div.
 #document
 | <html>
 |   <head>
@@ -637,6 +666,7 @@ eof-in-math
 #data
 <select><div><option><img>option</option></div></select>
 #errors
+1:1: ERROR: Expected a doctype token
 #document
 | <html>
 |   <head>
@@ -650,6 +680,8 @@ eof-in-math
 #data
 <select><input>
 #errors
+1:1: ERROR: Expected a doctype token
+1:16: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <html>
 |   <head>

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -646,3 +646,13 @@ eof-in-math
 |         <option>
 |           <img>
 |           "option"
+
+#data
+<select><input>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <input>

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -688,3 +688,43 @@ eof-in-math
 |   <body>
 |     <select>
 |     <input>
+
+#data
+<select><button><selectedcontent></button><option>X
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <button>
+|         <selectedcontent>
+|           "X"
+|       <option>
+|         "X"
+
+#data
+<select><button><selectedcontent></button><option>x<i>i<b>ib</i>b
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <button>
+|         <selectedcontent>
+|           "x"
+|           <i>
+|             "i"
+|             <b>
+|               "ib"
+|           <b>
+|             "b"
+|       <option>
+|         "x"
+|         <i>
+|           "i"
+|           <b>
+|             "ib"
+|         <b>
+|           "b"

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -309,12 +309,11 @@ div
 #data
 <option><XH<optgroup></optgroup>
 #errors
-(1,21): unexpected-start-tag-in-select
-(1,32): unexpected-end-tag-in-select
 #document-fragment
 select
 #document
 | <option>
+|   <xh<optgroup>
 
 #data
 <svg><foreignObject><div>foo</div><plaintext></foreignObject></svg><div>bar</div>
@@ -438,26 +437,22 @@ eof-in-math
 |     <select>
 |       <optgroup>
 |         <option>
-|       <hr>
+|         <hr>
 
 #data
 <select><optgroup><hr>
 #errors
-1:1: ERROR: Expected a doctype token
-1:23: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <html>
 |   <head>
 |   <body>
 |     <select>
 |       <optgroup>
-|       <hr>
+|         <hr>
 
 #data
 <select><option><optgroup><hr>
 #errors
-1:1: ERROR: Expected a doctype token
-1:31: ERROR: Premature end of file. Currently open tags: html, body, select.
 #document
 | <html>
 |   <head>
@@ -465,7 +460,7 @@ eof-in-math
 |     <select>
 |       <option>
 |       <optgroup>
-|       <hr>
+|         <hr>
 
 #data
 <table><tr><td><select><hr>
@@ -503,8 +498,6 @@ eof-in-math
 #data
 <table><tr><td><select><optgroup><option><hr>
 #errors
-1:1: ERROR: Expected a doctype token
-1:46: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select.
 #document
 | <html>
 |   <head>
@@ -516,13 +509,11 @@ eof-in-math
 |             <select>
 |               <optgroup>
 |                 <option>
-|               <hr>
+|                 <hr>
 
 #data
 <table><tr><td><select><optgroup><hr>
 #errors
-1:1: ERROR: Expected a doctype token
-1:38: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select.
 #document
 | <html>
 |   <head>
@@ -533,13 +524,11 @@ eof-in-math
 |           <td>
 |             <select>
 |               <optgroup>
-|               <hr>
+|                 <hr>
 
 #data
 <table><tr><td><select><option><optgroup><hr>
 #errors
-1:1: ERROR: Expected a doctype token
-1:46: ERROR: Premature end of file. Currently open tags: html, body, table, tbody, tr, td, select.
 #document
 | <html>
 |   <head>
@@ -551,4 +540,18 @@ eof-in-math
 |             <select>
 |               <option>
 |               <optgroup>
-|               <hr>
+|                 <hr>
+
+#data
+<select><div><i></div><option>option
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <div>
+|         <i>
+|       <option>
+|         <i>
+|           "option"

--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -687,4 +687,4 @@ eof-in-math
 |   <head>
 |   <body>
 |     <select>
-|       <input>
+|     <input>


### PR DESCRIPTION
This PR updates the tree-construction dat files for the HTML change which will allow additional tags within `<select>`:
https://github.com/whatwg/html/pull/10557