### PR TITLE
Test multiple option elements against selectedcontent

### DIFF
--- a/tree-construction/webkit02.dat
+++ b/tree-construction/webkit02.dat
@@ -730,6 +730,39 @@ eof-in-math
 |           "b"
 
 #data
+<select><button><selectedcontent></button><option>X<option>Y
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <button>
+|         <selectedcontent>
+|           "X"
+|       <option>
+|         "X"
+|       <option>
+|         "Y"
+
+#data
+<select><button><selectedcontent></button><option>X<option selected>Y
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <select>
+|       <button>
+|         <selectedcontent>
+|           "Y"
+|       <option>
+|         "X"
+|       <option>
+|         selected=""
+|         "Y"
+
+#data
 <font><select><option>a</option></font></select>
 #errors
 #document


### PR DESCRIPTION
Right now, there are no tests that check this behavior, even though it's a very important implementation detail that can be easily overlooked when implementing `selectedcontent` logic in parsers. In my opinion, it's perfectly reasonable to cover this with tests for the sake of completeness.