### PR TITLE
Escape angle brackets in serializer attribute tests

### DIFF
--- a/serializer/core.test
+++ b/serializer/core.test
@@ -13,7 +13,7 @@
 
 {"description": "proper attribute value non-quoting (with <)",
  "input": [["StartTag", "http://www.w3.org/1999/xhtml", "span", [{"namespace": null, "name": "title", "value": "foo<bar"}]]],
- "expected": ["<span title=foo<bar>"],
+ "expected": ["<span title=foo&lt;bar>"],
  "xhtml":    ["<span title=\"foo&lt;bar\">"]
 },
 
@@ -24,7 +24,7 @@
 
 {"description": "proper attribute value quoting (with >)",
  "input": [["StartTag", "http://www.w3.org/1999/xhtml", "span", [{"namespace": null, "name": "title", "value": "foo>bar"}]]],
- "expected": ["<span title=\"foo>bar\">"]
+ "expected": ["<span title=\"foo&gt;bar\">"]
 },
 
 {"description": "proper attribute value quoting (with \")",

--- a/serializer/options.test
+++ b/serializer/options.test
@@ -45,10 +45,10 @@
  "expected": ["<div irrelevant=\"\">"]
 },
 
-{"description": "escape less than signs in attribute values",
+{"description": "escape angle brackets in attribute values",
  "options": {"escape_lt_in_attrs": true},
  "input": [["StartTag", "http://www.w3.org/1999/xhtml", "a", [{"namespace": null, "name": "title", "value": "a<b>c&d"}]]],
- "expected": ["<a title=\"a&lt;b>c&amp;d\">"]
+ "expected": ["<a title=\"a&lt;b&gt;c&amp;d\">"]
 },
 
 {"description": "rcdata",


### PR DESCRIPTION
## Summary
- escape `<` and `>` in serializer attribute-value expectations
- align serializer tests with the HTML serialization change from whatwg/html#6235

Fixes #191.