### PR TITLE
Add tree construction tests for void elements inside phrasing containers

### DIFF
--- a/tree-construction/void-in-phrasing.dat
+++ b/tree-construction/void-in-phrasing.dat
@@ -1,0 +1,151 @@
+#data
+<!DOCTYPE html><body><p><br></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <br>
+
+#data
+<!DOCTYPE html><body><p><br>text</p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <br>
+|       "text"
+
+#data
+<!DOCTYPE html><body><p>before<br>after</p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       "before"
+|       <br>
+|       "after"
+
+#data
+<!DOCTYPE html><body><p><br><br></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <br>
+|       <br>
+
+#data
+<!DOCTYPE html><body><p>a<br>b<br>c</p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       "a"
+|       <br>
+|       "b"
+|       <br>
+|       "c"
+
+#data
+<!DOCTYPE html><body><h1><br></h1>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <h1>
+|       <br>
+
+#data
+<!DOCTYPE html><body><p><input></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <input>
+
+#data
+<!DOCTYPE html><body><p><img></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <img>
+
+#data
+<!DOCTYPE html><body><p><wbr></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <wbr>
+
+#data
+<!DOCTYPE html><body><p><embed></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <embed>
+
+#data
+<!DOCTYPE html><body><h2><input></h2>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <h2>
+|       <input>
+
+#data
+<!DOCTYPE html><body><em><br></em>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <em>
+|       <br>
+
+#data
+<!DOCTYPE html><body><strong><br>text</strong>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <strong>
+|       <br>
+|       "text"


### PR DESCRIPTION
## Summary

The existing tree construction test suite has no test cases for void elements (`<br>`, `<input>`, `<img>`, `<wbr>`, `<embed>`) as children of `<p>`, heading, or formatting elements.

This is a gap because the "in body" insertion mode handles these void elements via the "reconstruct the active formatting elements, insert an HTML element, pop" path - but a buggy parser could incorrectly route them through `closePElement` instead, causing `<p><br></p>` to produce `<p></p><br>` (closing the paragraph before inserting the break).

The combination `<p><br></p>` is common in real-world HTML.

## Test cases (13)

- `<br>` inside `<p>` (with/without surrounding text, multiple `<br>`s) - 5 cases
- `<br>` inside `<h1>` - 1 case
- `<input>`, `<img>`, `<wbr>`, `<embed>` inside `<p>` - 4 cases
- `<input>` inside `<h2>` - 1 case
- `<br>` inside formatting elements (`<em>`, `<strong>`) - 2 cases

All test cases use `<!DOCTYPE html>` prefix (no parse errors expected).

These tests add coverage for void elements (`<br>`, `<input>`, `<img>`, `<wbr>`, `<embed>`) as children of phrasing containers (`<p>`, headings, formatting elements). The html5lib reference parser already handles these cases correctly - the gap is in test suite coverage. These tests help other implementations catch a class of bug. CI failures are pre-existing and unrelated to this PR (parse5 hasn't implemented recent `<select>` content model changes).

## Relevant spec sections

- [12.2.6.4.7 "Any other start tag"](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody) - the `area, br, embed, img, keygen, wbr` case reconstructs active formatting elements, inserts, and immediately pops. It must NOT call the "close a p element" algorithm.