### PR TITLE
Fix <input><option> test case

### DIFF
--- a/tree-construction/tests_innerHTML_1.dat
+++ b/tree-construction/tests_innerHTML_1.dat
@@ -790,10 +790,10 @@ select
 #data
 <input><option>
 #errors
+(1,7): XXX-undefined-error
 #document-fragment
 select
 #document
-| <input>
 | <option>
 
 #data


### PR DESCRIPTION
When the changes were made to `<select>`, the test suite was updated (#178). As part of this an `<input>` was added to the serialization of the `<input><option>` case.

This doesn't match the spec though. In particular in 'A start tag whose tag name is "input"' in 13.2.6.4.7 says that "If the parser was created as part of the HTML fragment parsing algorithm (fragment case) and the context element passed to that algorithm is a select element" then the token should be ignored.

Since the context for the `<input><option>` case is "select", the input token should be ignored, resulting in a tree that contains just `<option>`.

Firefox and Safari _seem_ to agree here: https://wpt.fyi/results/html/syntax/parsing/html5lib_innerHTML_tests_innerHTML_1.html?label=experimental&label=master&aligned.

cc @josepharhar who wrote the spec change and updated the test suite.